### PR TITLE
fixup! Add new API function pcre2_set_optimization() for controlling enabled optimizations

### DIFF
--- a/src/pcre2_compile.c
+++ b/src/pcre2_compile.c
@@ -10590,6 +10590,25 @@ if ((options & PCRE2_LITERAL) == 0)
 
           case PSO_OPTMZ:
           optim_flags &= ~(p->value);
+
+          /* For backward compatibility the three original VERBs to disable
+          optimizations need to also update the corresponding external option. */
+
+          switch(p->value)
+            {
+            case PCRE2_OPTIM_AUTO_POSSESS:
+            cb.external_options |= PCRE2_NO_AUTO_POSSESS;
+            break;
+
+            case PCRE2_OPTIM_DOTSTAR_ANCHOR:
+            cb.external_options |= PCRE2_NO_DOTSTAR_ANCHOR;
+            break;
+
+            case PCRE2_OPTIM_START_OPTIMIZE:
+            cb.external_options |= PCRE2_NO_START_OPTIMIZE;
+            break;
+            }
+
           break;
 
           default:

--- a/testdata/testoutput15
+++ b/testdata/testoutput15
@@ -500,6 +500,8 @@ No match
         End
 ------------------------------------------------------------------
 Capture group count = 0
+Compile options: <none>
+Overall options: no_auto_possess
 Optimizations: dotstar_anchor,start_optimize
 Starting code units: 0 1 2 3 4 5 6 7 8 9 A B C D E F G H I J K L M N O P
   Q R S T U V W X Y Z _ a b c d e f g h i j k l m n o p q r s t u v w x y z

--- a/testdata/testoutput2
+++ b/testdata/testoutput2
@@ -13944,6 +13944,8 @@ Subject length lower bound = 1
 
 /(*NO_DOTSTAR_ANCHOR)(?s).*\d/info
 Capture group count = 0
+Compile options: <none>
+Overall options: no_dotstar_anchor
 Optimizations: auto_possess,start_optimize
 Subject length lower bound = 1
 


### PR DESCRIPTION
open coded and could be better split at least into a prerequisite and the required change