### PR TITLE
fixup! Add new API function pcre2_set_optimization() for controlling enabled optimizations

### DIFF
--- a/doc/html/pcre2pattern.html
+++ b/doc/html/pcre2pattern.html
@@ -2243,7 +2243,7 @@ package, and PCRE1 copied it from there. It found its way into Perl at release
 PCRE2 has an optimization that automatically "possessifies" certain simple
 pattern constructs. For example, the sequence A+B is treated as A++B because
 there is no point in backtracking into a sequence of A's when B must follow.
-This feature can be disabled by the PCRE2_NO_AUTOPOSSESS option, or starting
+This feature can be disabled by the PCRE2_NO_AUTO_POSSESS option, or starting
 the pattern with (*NO_AUTO_POSSESS).
 </P>
 <P>

--- a/doc/pcre2pattern.3
+++ b/doc/pcre2pattern.3
@@ -2242,7 +2242,7 @@ package, and PCRE1 copied it from there. It found its way into Perl at release
 PCRE2 has an optimization that automatically "possessifies" certain simple
 pattern constructs. For example, the sequence A+B is treated as A++B because
 there is no point in backtracking into a sequence of A's when B must follow.
-This feature can be disabled by the PCRE2_NO_AUTOPOSSESS option, or starting
+This feature can be disabled by the PCRE2_NO_AUTO_POSSESS option, or starting
 the pattern with (*NO_AUTO_POSSESS).
 .P
 When a pattern contains an unlimited repeat inside a group that can itself be

--- a/src/pcre2.h.generic
+++ b/src/pcre2.h.generic
@@ -464,6 +464,17 @@ released, the numbers must not be changed. */
 #define PCRE2_CONFIG_COMPILED_WIDTHS        14
 #define PCRE2_CONFIG_TABLES_LENGTH          15
 
+/* Optimization directives for pcre2_set_optimize().
+For binary compatibility, only add to this list; do not renumber. */
+
+#define PCRE2_OPTIMIZATION_NONE   0
+#define PCRE2_OPTIMIZATION_FULL   1
+#define PCRE2_DO_AUTO_POSSESS     2
+/* Do not use 3 */
+#define PCRE2_DO_DOTSTAR_ANCHOR   4
+/* Do not use 5 */
+#define PCRE2_DO_START_OPTIMIZE   6
+/* Do not use 7 */
 
 /* Types for code units in patterns and subject strings. */
 
@@ -912,6 +923,7 @@ pcre2_compile are called by application code. */
 #define pcre2_set_newline                     PCRE2_SUFFIX(pcre2_set_newline_)
 #define pcre2_set_parens_nest_limit           PCRE2_SUFFIX(pcre2_set_parens_nest_limit_)
 #define pcre2_set_offset_limit                PCRE2_SUFFIX(pcre2_set_offset_limit_)
+#define pcre2_set_optimize                    PCRE2_SUFFIX(pcre2_set_optimize_)
 #define pcre2_set_substitute_callout          PCRE2_SUFFIX(pcre2_set_substitute_callout_)
 #define pcre2_substitute                      PCRE2_SUFFIX(pcre2_substitute_)
 #define pcre2_substring_copy_byname           PCRE2_SUFFIX(pcre2_substring_copy_byname_)

--- a/src/pcre2.h.generic
+++ b/src/pcre2.h.generic
@@ -628,7 +628,9 @@ PCRE2_EXP_DECL int PCRE2_CALL_CONVENTION \
   pcre2_set_parens_nest_limit(pcre2_compile_context *, uint32_t); \
 PCRE2_EXP_DECL int PCRE2_CALL_CONVENTION \
   pcre2_set_compile_recursion_guard(pcre2_compile_context *, \
-    int (*)(uint32_t, void *), void *);
+    int (*)(uint32_t, void *), void *); \
+PCRE2_EXP_DECL int PCRE2_CALL_CONVENTION \
+  pcre2_set_optimize(pcre2_compile_context *, uint32_t);
 
 #define PCRE2_MATCH_CONTEXT_FUNCTIONS \
 PCRE2_EXP_DECL pcre2_match_context *PCRE2_CALL_CONVENTION \

--- a/src/pcre2.h.in
+++ b/src/pcre2.h.in
@@ -464,6 +464,17 @@ released, the numbers must not be changed. */
 #define PCRE2_CONFIG_COMPILED_WIDTHS        14
 #define PCRE2_CONFIG_TABLES_LENGTH          15
 
+/* Optimization directives for pcre2_set_optimize().
+For binary compatibility, only add to this list; do not renumber. */
+
+#define PCRE2_OPTIMIZATION_NONE   0
+#define PCRE2_OPTIMIZATION_FULL   1
+#define PCRE2_DO_AUTO_POSSESS     2
+/* Do not use 3 */
+#define PCRE2_DO_DOTSTAR_ANCHOR   4
+/* Do not use 5 */
+#define PCRE2_DO_START_OPTIMIZE   6
+/* Do not use 7 */
 
 /* Types for code units in patterns and subject strings. */
 
@@ -912,6 +923,7 @@ pcre2_compile are called by application code. */
 #define pcre2_set_newline                     PCRE2_SUFFIX(pcre2_set_newline_)
 #define pcre2_set_parens_nest_limit           PCRE2_SUFFIX(pcre2_set_parens_nest_limit_)
 #define pcre2_set_offset_limit                PCRE2_SUFFIX(pcre2_set_offset_limit_)
+#define pcre2_set_optimize                    PCRE2_SUFFIX(pcre2_set_optimize_)
 #define pcre2_set_substitute_callout          PCRE2_SUFFIX(pcre2_set_substitute_callout_)
 #define pcre2_substitute                      PCRE2_SUFFIX(pcre2_substitute_)
 #define pcre2_substring_copy_byname           PCRE2_SUFFIX(pcre2_substring_copy_byname_)

--- a/src/pcre2.h.in
+++ b/src/pcre2.h.in
@@ -628,7 +628,9 @@ PCRE2_EXP_DECL int PCRE2_CALL_CONVENTION \
   pcre2_set_parens_nest_limit(pcre2_compile_context *, uint32_t); \
 PCRE2_EXP_DECL int PCRE2_CALL_CONVENTION \
   pcre2_set_compile_recursion_guard(pcre2_compile_context *, \
-    int (*)(uint32_t, void *), void *);
+    int (*)(uint32_t, void *), void *); \
+PCRE2_EXP_DECL int PCRE2_CALL_CONVENTION \
+  pcre2_set_optimize(pcre2_compile_context *, uint32_t);
 
 #define PCRE2_MATCH_CONTEXT_FUNCTIONS \
 PCRE2_EXP_DECL pcre2_match_context *PCRE2_CALL_CONVENTION \

--- a/src/pcre2_compile.c
+++ b/src/pcre2_compile.c
@@ -834,7 +834,8 @@ enum { PSO_OPT,     /* Value is an option bit */
        PSO_BSR,     /* Value is a \R type */
        PSO_LIMH,    /* Read integer value for heap limit */
        PSO_LIMM,    /* Read integer value for match limit */
-       PSO_LIMD     /* Read integer value for depth limit */
+       PSO_LIMD,    /* Read integer value for depth limit */
+       PSO_OPTMZ    /* Value is an optimization bit */
      };
 
 typedef struct pso {
@@ -852,10 +853,10 @@ static const pso pso_list[] = {
   { STRING_UCP_RIGHTPAR,                4, PSO_OPT, PCRE2_UCP },
   { STRING_NOTEMPTY_RIGHTPAR,           9, PSO_FLG, PCRE2_NOTEMPTY_SET },
   { STRING_NOTEMPTY_ATSTART_RIGHTPAR,  17, PSO_FLG, PCRE2_NE_ATST_SET },
-  { STRING_NO_AUTO_POSSESS_RIGHTPAR,   16, PSO_OPT, PCRE2_NO_AUTO_POSSESS },
-  { STRING_NO_DOTSTAR_ANCHOR_RIGHTPAR, 18, PSO_OPT, PCRE2_NO_DOTSTAR_ANCHOR },
+  { STRING_NO_AUTO_POSSESS_RIGHTPAR,   16, PSO_OPTMZ, PCRE2_OPTIM_AUTO_POSSESS },
+  { STRING_NO_DOTSTAR_ANCHOR_RIGHTPAR, 18, PSO_OPTMZ, PCRE2_OPTIM_DOTSTAR_ANCHOR },
   { STRING_NO_JIT_RIGHTPAR,             7, PSO_FLG, PCRE2_NOJIT },
-  { STRING_NO_START_OPT_RIGHTPAR,      13, PSO_OPT, PCRE2_NO_START_OPTIMIZE },
+  { STRING_NO_START_OPT_RIGHTPAR,      13, PSO_OPTMZ, PCRE2_OPTIM_START_OPTIMIZE },
   { STRING_LIMIT_HEAP_EQ,              11, PSO_LIMH, 0 },
   { STRING_LIMIT_MATCH_EQ,             12, PSO_LIMM, 0 },
   { STRING_LIMIT_DEPTH_EQ,             12, PSO_LIMD, 0 },
@@ -8883,13 +8884,14 @@ Arguments:
   cb             points to the compile data block
   atomcount      atomic group level
   inassert       TRUE if in an assertion
+  dotstar_anchor TRUE if automatic anchoring optimization is enabled
 
 Returns:     TRUE or FALSE
 */
 
 static BOOL
 is_anchored(PCRE2_SPTR code, uint32_t bracket_map, compile_block *cb,
-  int atomcount, BOOL inassert)
+  int atomcount, BOOL inassert, BOOL dotstar_anchor)
 {
 do {
    PCRE2_SPTR scode = first_significant_code(
@@ -8901,7 +8903,7 @@ do {
    if (op == OP_BRA  || op == OP_BRAPOS ||
        op == OP_SBRA || op == OP_SBRAPOS)
      {
-     if (!is_anchored(scode, bracket_map, cb, atomcount, inassert))
+     if (!is_anchored(scode, bracket_map, cb, atomcount, inassert, dotstar_anchor))
        return FALSE;
      }
 
@@ -8912,14 +8914,14 @@ do {
      {
      int n = GET2(scode, 1+LINK_SIZE);
      uint32_t new_map = bracket_map | ((n < 32)? (1u << n) : 1);
-     if (!is_anchored(scode, new_map, cb, atomcount, inassert)) return FALSE;
+     if (!is_anchored(scode, new_map, cb, atomcount, inassert, dotstar_anchor)) return FALSE;
      }
 
    /* Positive forward assertion */
 
    else if (op == OP_ASSERT || op == OP_ASSERT_NA)
      {
-     if (!is_anchored(scode, bracket_map, cb, atomcount, TRUE)) return FALSE;
+     if (!is_anchored(scode, bracket_map, cb, atomcount, TRUE, dotstar_anchor)) return FALSE;
      }
 
    /* Condition. If there is no second branch, it can't be anchored. */
@@ -8927,7 +8929,7 @@ do {
    else if (op == OP_COND || op == OP_SCOND)
      {
      if (scode[GET(scode,1)] != OP_ALT) return FALSE;
-     if (!is_anchored(scode, bracket_map, cb, atomcount, inassert))
+     if (!is_anchored(scode, bracket_map, cb, atomcount, inassert, dotstar_anchor))
        return FALSE;
      }
 
@@ -8935,7 +8937,7 @@ do {
 
    else if (op == OP_ONCE)
      {
-     if (!is_anchored(scode, bracket_map, cb, atomcount + 1, inassert))
+     if (!is_anchored(scode, bracket_map, cb, atomcount + 1, inassert, dotstar_anchor))
        return FALSE;
      }
 
@@ -8950,8 +8952,7 @@ do {
              op == OP_TYPEPOSSTAR))
      {
      if (scode[1] != OP_ALLANY || (bracket_map & cb->backref_map) != 0 ||
-         atomcount > 0 || cb->had_pruneorskip || inassert ||
-         (cb->external_options & PCRE2_NO_DOTSTAR_ANCHOR) != 0)
+         atomcount > 0 || cb->had_pruneorskip || inassert || !dotstar_anchor)
        return FALSE;
      }
 
@@ -8988,13 +8989,14 @@ Arguments:
   cb             points to the compile data
   atomcount      atomic group level
   inassert       TRUE if in an assertion
+  dotstar_anchor TRUE if automatic anchoring optimization is enabled
 
 Returns:         TRUE or FALSE
 */
 
 static BOOL
 is_startline(PCRE2_SPTR code, unsigned int bracket_map, compile_block *cb,
-  int atomcount, BOOL inassert)
+  int atomcount, BOOL inassert, BOOL dotstar_anchor)
 {
 do {
    PCRE2_SPTR scode = first_significant_code(
@@ -9025,7 +9027,8 @@ do {
        return FALSE;
 
        default:     /* Assertion */
-       if (!is_startline(scode, bracket_map, cb, atomcount, TRUE)) return FALSE;
+       if (!is_startline(scode, bracket_map, cb, atomcount, TRUE, dotstar_anchor))
+         return FALSE;
        do scode += GET(scode, 1); while (*scode == OP_ALT);
        scode += 1 + LINK_SIZE;
        break;
@@ -9039,7 +9042,7 @@ do {
    if (op == OP_BRA  || op == OP_BRAPOS ||
        op == OP_SBRA || op == OP_SBRAPOS)
      {
-     if (!is_startline(scode, bracket_map, cb, atomcount, inassert))
+     if (!is_startline(scode, bracket_map, cb, atomcount, inassert, dotstar_anchor))
        return FALSE;
      }
 
@@ -9050,14 +9053,15 @@ do {
      {
      int n = GET2(scode, 1+LINK_SIZE);
      unsigned int new_map = bracket_map | ((n < 32)? (1u << n) : 1);
-     if (!is_startline(scode, new_map, cb, atomcount, inassert)) return FALSE;
+     if (!is_startline(scode, new_map, cb, atomcount, inassert, dotstar_anchor))
+       return FALSE;
      }
 
    /* Positive forward assertions */
 
    else if (op == OP_ASSERT || op == OP_ASSERT_NA)
      {
-     if (!is_startline(scode, bracket_map, cb, atomcount, TRUE))
+     if (!is_startline(scode, bracket_map, cb, atomcount, TRUE, dotstar_anchor))
        return FALSE;
      }
 
@@ -9065,7 +9069,7 @@ do {
 
    else if (op == OP_ONCE)
      {
-     if (!is_startline(scode, bracket_map, cb, atomcount + 1, inassert))
+     if (!is_startline(scode, bracket_map, cb, atomcount + 1, inassert, dotstar_anchor))
        return FALSE;
      }
 
@@ -9079,8 +9083,7 @@ do {
    else if (op == OP_TYPESTAR || op == OP_TYPEMINSTAR || op == OP_TYPEPOSSTAR)
      {
      if (scode[1] != OP_ANY || (bracket_map & cb->backref_map) != 0 ||
-         atomcount > 0 || cb->had_pruneorskip || inassert ||
-         (cb->external_options & PCRE2_NO_DOTSTAR_ANCHOR) != 0)
+         atomcount > 0 || cb->had_pruneorskip || inassert || !dotstar_anchor)
        return FALSE;
      }
 
@@ -10362,6 +10365,10 @@ int regexrc;                          /* Return from compile */
 
 uint32_t i;                           /* Local loop counter */
 
+/* Enable all optimizations by default. */
+uint32_t optim_flags = ccontext != NULL ? ccontext->optimization_flags :
+                                          PCRE2_OPTIMIZATION_ALL;
+
 /* Comments at the head of this file explain about these variables. */
 
 uint32_t stack_groupinfo[GROUPINFO_DEFAULT_SIZE];
@@ -10431,6 +10438,18 @@ if (patlen > ccontext->max_pattern_length)
   *errorptr = ERR88;
   return NULL;
   }
+
+/* Optimization flags in 'options' can override those in the compile context.
+This is because some options to disable optimizations were added before the
+optimization flags word existed, and we need to continue supporting them
+for backwards compatibility. */
+
+if (options & PCRE2_NO_AUTO_POSSESS)
+  optim_flags &= ~PCRE2_OPTIM_AUTO_POSSESS;
+if (options & PCRE2_NO_DOTSTAR_ANCHOR)
+  optim_flags &= ~PCRE2_OPTIM_DOTSTAR_ANCHOR;
+if (options & PCRE2_NO_START_OPTIMIZE)
+  optim_flags &= ~PCRE2_OPTIM_START_OPTIMIZE;
 
 /* From here on, all returns from this function should end up going via the
 EXIT label. */
@@ -10568,6 +10587,13 @@ if ((options & PCRE2_LITERAL) == 0)
             else limit_depth = c;
           skipatstart = ++pp;
           break;
+
+          case PSO_OPTMZ:
+          optim_flags &= ~(p->value);
+          break;
+
+          default:
+          PCRE2_UNREACHABLE();
           }
         break;   /* Out of the table scan loop */
         }
@@ -10863,6 +10889,7 @@ re->top_bracket = 0;
 re->top_backref = 0;
 re->name_entry_size = cb.name_entry_size;
 re->name_count = cb.names_found;
+re->optimization_flags = optim_flags;
 
 /* The basic block is immediately followed by the name table, and the compiled
 code follows after that. */
@@ -11005,7 +11032,7 @@ used in this code because at least one compiler gives a warning about loss of
 "const" attribute if the cast (PCRE2_UCHAR *)codestart is used directly in the
 function call. */
 
-if (errorcode == 0 && (re->overall_options & PCRE2_NO_AUTO_POSSESS) == 0)
+if (errorcode == 0 && (optim_flags & PCRE2_OPTIM_AUTO_POSSESS))
   {
   PCRE2_UCHAR *temp = (PCRE2_UCHAR *)codestart;
   if (PRIV(auto_possessify)(temp, &cb) != 0) errorcode = ERR80;
@@ -11022,17 +11049,17 @@ there are no occurrences of *PRUNE or *SKIP (though there is an option to
 disable this case). */
 
 if ((re->overall_options & PCRE2_ANCHORED) == 0 &&
-     is_anchored(codestart, 0, &cb, 0, FALSE))
+     is_anchored(codestart, 0, &cb, 0, FALSE, (optim_flags & PCRE2_OPTIM_DOTSTAR_ANCHOR) != 0))
   re->overall_options |= PCRE2_ANCHORED;
 
 /* Set up the first code unit or startline flag, the required code unit, and
-then study the pattern. This code need not be obeyed if PCRE2_NO_START_OPTIMIZE
-is set, as the data it would create will not be used. Note that a first code
+then study the pattern. This code need not be obeyed if PCRE2_OPTIM_START_OPTIMIZE
+is disabled, as the data it would create will not be used. Note that a first code
 unit (but not the startline flag) is useful for anchored patterns because it
 can still give a quick "no match" and also avoid searching for a last code
 unit. */
 
-if ((re->overall_options & PCRE2_NO_START_OPTIMIZE) == 0)
+if (optim_flags & PCRE2_OPTIM_START_OPTIMIZE)
   {
   int minminlength = 0;  /* For minimal minlength from first/required CU */
 
@@ -11096,7 +11123,7 @@ if ((re->overall_options & PCRE2_NO_START_OPTIMIZE) == 0)
   that disables this case.) */
 
   else if ((re->overall_options & PCRE2_ANCHORED) == 0 &&
-           is_startline(codestart, 0, &cb, 0, FALSE))
+           is_startline(codestart, 0, &cb, 0, FALSE, (optim_flags & PCRE2_OPTIM_DOTSTAR_ANCHOR) != 0))
     re->flags |= PCRE2_STARTLINE;
 
   /* Handle the "required code unit", if one is set. In the UTF case we can

--- a/src/pcre2_compile.c
+++ b/src/pcre2_compile.c
@@ -10590,6 +10590,25 @@ if ((options & PCRE2_LITERAL) == 0)
 
           case PSO_OPTMZ:
           optim_flags &= ~(p->value);
+
+          /* For backward compatibility the three original VERBs to disable
+          optimizations need to also update the corresponding external option. */
+
+          switch(p->value)
+            {
+            case PCRE2_OPTIM_AUTO_POSSESS:
+            cb.external_options |= PCRE2_NO_AUTO_POSSESS;
+            break;
+
+            case PCRE2_OPTIM_DOTSTAR_ANCHOR:
+            cb.external_options |= PCRE2_NO_DOTSTAR_ANCHOR;
+            break;
+
+            case PCRE2_OPTIM_START_OPTIMIZE:
+            cb.external_options |= PCRE2_NO_START_OPTIMIZE;
+            break;
+            }
+
           break;
 
           default:

--- a/src/pcre2_context.c
+++ b/src/pcre2_context.c
@@ -141,7 +141,8 @@ pcre2_compile_context PRIV(default_compile_context) = {
   NEWLINE_DEFAULT,                           /* Newline convention */
   PARENS_NEST_LIMIT,                         /* As it says */
   0,                                         /* Extra options */
-  MAX_VARLOOKBEHIND                          /* As it says */
+  MAX_VARLOOKBEHIND,                         /* As it says */
+  PCRE2_OPTIMIZATION_ALL                     /* All optimizations enabled */
   };
 
 /* The create function copies the default into the new memory, but must
@@ -409,6 +410,38 @@ ccontext->stack_guard_data = user_data;
 return 0;
 }
 
+static const uint16_t optimize_setbits[] = {
+  OPTIM_SETBITS
+};
+static const uint16_t optimize_clearbits[] = {
+  OPTIM_CLEARBITS
+};
+
+/* the two arrays above must be kept in sync */
+typedef char CHECK_OPTIM_BITS_ARRAYS[ARRAY_SIZE(optimize_setbits) == ARRAY_SIZE(optimize_clearbits) ? 1 : -1];
+
+PCRE2_EXP_DEFN int PCRE2_CALL_CONVENTION
+pcre2_set_optimize(pcre2_compile_context *ccontext, uint32_t directive)
+{
+/* We are reusing some symbolic constants which were already defined before
+ * pcre2_set_optimize() was added; convert to indexes in conversion tables */
+if (directive == PCRE2_NO_AUTO_POSSESS)
+  directive = 3;
+else if (directive == PCRE2_NO_DOTSTAR_ANCHOR)
+  directive = 5;
+else if (directive == PCRE2_NO_START_OPTIMIZE)
+  directive = 7;
+
+if (directive < (sizeof(optimize_setbits)/sizeof(uint16_t)))
+  {
+  /* Both of the public directive → private flag conversion tables should
+   * be the same size, but let's make sure */
+  PCRE2_ASSERT(directive < (sizeof(optimize_clearbits)/sizeof(uint16_t)));
+  ccontext->optimization_flags |= optimize_setbits[directive];
+  ccontext->optimization_flags &= ~optimize_clearbits[directive];
+  }
+return 0;
+}
 
 /* ------------ Match context ------------ */
 

--- a/src/pcre2_dfa_match.c
+++ b/src/pcre2_dfa_match.c
@@ -3432,7 +3432,7 @@ if ((re->flags & PCRE2_MODE_MASK) != PCRE2_CODE_UNIT_WIDTH/8)
 /* PCRE2_NOTEMPTY and PCRE2_NOTEMPTY_ATSTART are match-time flags in the
 options variable for this function. Users of PCRE2 who are not calling the
 function directly would like to have a way of setting these flags, in the same
-way that they can set pcre2_compile() flags like PCRE2_NO_AUTOPOSSESS with
+way that they can set pcre2_compile() flags like PCRE2_NO_AUTO_POSSESS with
 constructions like (*NO_AUTOPOSSESS). To enable this, (*NOTEMPTY) and
 (*NOTEMPTY_ATSTART) set bits in the pattern's "flag" function which can now be
 transferred to the options for this function. The bits are guaranteed to be
@@ -3699,7 +3699,7 @@ for (;;)
   these, for testing and for ensuring that all callouts do actually occur.
   The optimizations must also be avoided when restarting a DFA match. */
 
-  if ((re->overall_options & PCRE2_NO_START_OPTIMIZE) == 0 &&
+  if ((re->optimization_flags & PCRE2_OPTIM_START_OPTIMIZE) &&
       (options & PCRE2_DFA_RESTART) == 0)
     {
     /* If firstline is TRUE, the start of the match is constrained to the first

--- a/src/pcre2_internal.h
+++ b/src/pcre2_internal.h
@@ -609,6 +609,36 @@ total length of the tables. */
 #define ctypes_offset (cbits_offset + cbit_length)  /* Character types */
 #define TABLES_LENGTH (ctypes_offset + 256)
 
+/* Private flags used in compile_context.optimization_flags */
+
+#define PCRE2_OPTIM_AUTO_POSSESS    0x00000001u
+#define PCRE2_OPTIM_DOTSTAR_ANCHOR  0x00000002u
+#define PCRE2_OPTIM_START_OPTIMIZE  0x00000004u
+
+#define PCRE2_OPTIMIZATION_ALL      0x00000007u
+
+/* Tables for converting public optimization directives listed in
+pcre2.h to private optimization flags. */
+
+#define OPTIM_SETBITS \
+  0,                         /* no optimization */   \
+  PCRE2_OPTIMIZATION_ALL,    /* full optimization */ \
+  PCRE2_OPTIM_AUTO_POSSESS,                          \
+  0,                                                 \
+  PCRE2_OPTIM_DOTSTAR_ANCHOR,                        \
+  0,                                                 \
+  PCRE2_OPTIM_START_OPTIMIZE,                        \
+  0
+
+#define OPTIM_CLEARBITS \
+  PCRE2_OPTIMIZATION_ALL,    /* no optimization */   \
+  0,                         /* full optimization */ \
+  0,                                                 \
+  PCRE2_OPTIM_AUTO_POSSESS,                          \
+  0,                                                 \
+  PCRE2_OPTIM_DOTSTAR_ANCHOR,                        \
+  0,                                                 \
+  PCRE2_OPTIM_START_OPTIMIZE
 
 /* -------------------- Character and string names ------------------------ */
 

--- a/src/pcre2_intmodedep.h
+++ b/src/pcre2_intmodedep.h
@@ -579,6 +579,7 @@ typedef struct pcre2_real_compile_context {
   uint32_t parens_nest_limit;
   uint32_t extra_options;
   uint32_t max_varlookbehind;
+  uint32_t optimization_flags;
 } pcre2_real_compile_context;
 
 /* The real match context structure. */
@@ -646,6 +647,7 @@ typedef struct pcre2_real_code {
   uint16_t top_backref;           /* Highest numbered back reference */
   uint16_t name_entry_size;       /* Size (code units) of table entries */
   uint16_t name_count;            /* Number of name entries in the table */
+  uint32_t optimization_flags;    /* Optimizations enabled at compile time */
 } pcre2_real_code;
 
 /* The real match data structure. Define ovector as large as it can ever

--- a/src/pcre2_jit_compile.c
+++ b/src/pcre2_jit_compile.c
@@ -14474,7 +14474,7 @@ if (!check_opcode_types(common, common->start, ccend))
   }
 
 /* Checking flags and updating ovector_start. */
-if (mode == PCRE2_JIT_COMPLETE && (re->flags & PCRE2_LASTSET) != 0 && (re->overall_options & PCRE2_NO_START_OPTIMIZE) == 0)
+if (mode == PCRE2_JIT_COMPLETE && (re->flags & PCRE2_LASTSET) != 0 && (re->optimization_flags & PCRE2_OPTIM_START_OPTIMIZE))
   {
   common->req_char_ptr = common->ovector_start;
   common->ovector_start += sizeof(sljit_sw);
@@ -14534,7 +14534,7 @@ memset(common->private_data_ptrs, 0, total_length * sizeof(sljit_s32));
 
 private_data_size = common->cbra_ptr + (re->top_bracket + 1) * sizeof(sljit_sw);
 
-if ((re->overall_options & PCRE2_ANCHORED) == 0 && (re->overall_options & PCRE2_NO_START_OPTIMIZE) == 0 && !common->has_skip_in_assert_back)
+if ((re->overall_options & PCRE2_ANCHORED) == 0 && (re->optimization_flags & PCRE2_OPTIM_START_OPTIMIZE) && !common->has_skip_in_assert_back)
   detect_early_fail(common, common->start, &private_data_size, 0, 0);
 
 set_private_data_ptrs(common, &private_data_size, ccend);
@@ -14600,7 +14600,7 @@ if ((re->overall_options & PCRE2_ANCHORED) == 0)
   mainloop_label = mainloop_entry(common);
   continue_match_label = LABEL();
   /* Forward search if possible. */
-  if ((re->overall_options & PCRE2_NO_START_OPTIMIZE) == 0)
+  if (re->optimization_flags & PCRE2_OPTIM_START_OPTIMIZE)
     {
     if (mode == PCRE2_JIT_COMPLETE && fast_forward_first_n_chars(common))
       ;
@@ -14615,7 +14615,7 @@ if ((re->overall_options & PCRE2_ANCHORED) == 0)
 else
   continue_match_label = LABEL();
 
-if (mode == PCRE2_JIT_COMPLETE && re->minlength > 0 && (re->overall_options & PCRE2_NO_START_OPTIMIZE) == 0)
+if (mode == PCRE2_JIT_COMPLETE && re->minlength > 0 && (re->optimization_flags & PCRE2_OPTIM_START_OPTIMIZE))
   {
   OP1(SLJIT_MOV, SLJIT_RETURN_REG, 0, SLJIT_IMM, PCRE2_ERROR_NOMATCH);
   OP2(SLJIT_ADD, TMP2, 0, STR_PTR, 0, SLJIT_IMM, IN_UCHARS(re->minlength));

--- a/src/pcre2_match.c
+++ b/src/pcre2_match.c
@@ -6788,7 +6788,7 @@ if ((re->flags & PCRE2_MODE_MASK) != PCRE2_CODE_UNIT_WIDTH/8)
 /* PCRE2_NOTEMPTY and PCRE2_NOTEMPTY_ATSTART are match-time flags in the
 options variable for this function. Users of PCRE2 who are not calling the
 function directly would like to have a way of setting these flags, in the same
-way that they can set pcre2_compile() flags like PCRE2_NO_AUTOPOSSESS with
+way that they can set pcre2_compile() flags like PCRE2_NO_AUTO_POSSESS with
 constructions like (*NO_AUTOPOSSESS). To enable this, (*NOTEMPTY) and
 (*NOTEMPTY_ATSTART) set bits in the pattern's "flag" function which we now
 transfer to the options for this function. The bits are guaranteed to be
@@ -7326,7 +7326,7 @@ for(;;)
   However, there is an option (settable at compile time) that disables these,
   for testing and for ensuring that all callouts do actually occur. */
 
-  if ((re->overall_options & PCRE2_NO_START_OPTIMIZE) == 0)
+  if (re->optimization_flags & PCRE2_OPTIM_START_OPTIMIZE)
     {
     /* If firstline is TRUE, the start of the match is constrained to the first
     line of a multiline string. That is, the match must be before or at the

--- a/src/pcre2_util.h
+++ b/src/pcre2_util.h
@@ -41,6 +41,8 @@ POSSIBILITY OF SUCH DAMAGE.
 #ifndef PCRE2_UTIL_H_IDEMPOTENT_GUARD
 #define PCRE2_UTIL_H_IDEMPOTENT_GUARD
 
+#define ARRAY_SIZE(a) (sizeof(a) / sizeof(a[0]))
+
 /* Assertion macros */
 
 #ifdef HAVE_BUILTIN_UNREACHABLE

--- a/src/pcre2test.c
+++ b/src/pcre2test.c
@@ -4361,6 +4361,33 @@ else fprintf(outfile, "%s%s%s%s%s%s%s%s%s%s%s%s%s%s",
 }
 
 
+/*************************************************
+*           Show optimization flags              *
+*************************************************/
+
+/*
+Arguments:
+  flags       an options word
+  before      text to print before
+  after       text to print after
+
+Returns:      nothing
+*/
+
+static void
+show_optimize_flags(uint32_t flags, const char *before, const char *after)
+{
+if (flags == 0) fprintf(outfile, "%s <none>%s", before, after);
+else fprintf(outfile, "%s%s%s%s%s%s%s",
+  before,
+  ((flags & PCRE2_OPTIM_AUTO_POSSESS) != 0) ? "auto_possess" : "",
+  ((flags & PCRE2_OPTIM_AUTO_POSSESS) != 0 && (flags >> 1) != 0) ? "," : "",
+  ((flags & PCRE2_OPTIM_DOTSTAR_ANCHOR) != 0) ? "dotstar_anchor" : "",
+  ((flags & PCRE2_OPTIM_DOTSTAR_ANCHOR) != 0 && (flags >> 2) != 0) ? "," : "",
+  ((flags & PCRE2_OPTIM_START_OPTIMIZE) != 0) ? "start_optimize" : "",
+  after);
+}
+
 
 #ifdef SUPPORT_PCRE2_8
 /*************************************************
@@ -4777,6 +4804,9 @@ if ((pat_patctl.control & CTL_INFO) != 0)
   if (extra_options != 0)
     show_compile_extra_options(extra_options, "Extra options:", "\n");
 
+  if (FLD(compiled_code, optimization_flags) != PCRE2_OPTIMIZATION_ALL)
+    show_optimize_flags(FLD(compiled_code, optimization_flags), "Optimizations: ", "\n");
+
   if (jchanged) fprintf(outfile, "Duplicate name status changes\n");
 
   if ((pat_patctl.control2 & CTL2_BSR_SET) != 0 ||
@@ -4879,7 +4909,7 @@ if ((pat_patctl.control & CTL_INFO) != 0)
       }
     }
 
-  if ((FLD(compiled_code, overall_options) & PCRE2_NO_START_OPTIMIZE) == 0)
+  if (FLD(compiled_code, optimization_flags) & PCRE2_OPTIM_START_OPTIMIZE)
     fprintf(outfile, "Subject length lower bound = %d\n", minlength);
 
   if (pat_patctl.jit != 0 && (pat_patctl.control & CTL_JITVERIFY) != 0)

--- a/testdata/testoutput15
+++ b/testdata/testoutput15
@@ -500,6 +500,8 @@ No match
         End
 ------------------------------------------------------------------
 Capture group count = 0
+Compile options: <none>
+Overall options: no_auto_possess
 Optimizations: dotstar_anchor,start_optimize
 Starting code units: 0 1 2 3 4 5 6 7 8 9 A B C D E F G H I J K L M N O P
   Q R S T U V W X Y Z _ a b c d e f g h i j k l m n o p q r s t u v w x y z

--- a/testdata/testoutput15
+++ b/testdata/testoutput15
@@ -477,6 +477,7 @@ Failed: error -52: nested recursion at the same subject position
 ------------------------------------------------------------------
 Capture group count = 0
 Options: no_auto_possess
+Optimizations: dotstar_anchor,start_optimize
 Starting code units: 0 1 2 3 4 5 6 7 8 9 A B C D E F G H I J K L M N O P
   Q R S T U V W X Y Z _ a b c d e f g h i j k l m n o p q r s t u v w x y z
 Subject length lower bound = 1
@@ -499,8 +500,7 @@ No match
         End
 ------------------------------------------------------------------
 Capture group count = 0
-Compile options: <none>
-Overall options: no_auto_possess
+Optimizations: dotstar_anchor,start_optimize
 Starting code units: 0 1 2 3 4 5 6 7 8 9 A B C D E F G H I J K L M N O P
   Q R S T U V W X Y Z _ a b c d e f g h i j k l m n o p q r s t u v w x y z
 Subject length lower bound = 1

--- a/testdata/testoutput2
+++ b/testdata/testoutput2
@@ -13944,6 +13944,8 @@ Subject length lower bound = 1
 
 /(*NO_DOTSTAR_ANCHOR)(?s).*\d/info
 Capture group count = 0
+Compile options: <none>
+Overall options: no_dotstar_anchor
 Optimizations: auto_possess,start_optimize
 Subject length lower bound = 1
 

--- a/testdata/testoutput2
+++ b/testdata/testoutput2
@@ -13601,6 +13601,7 @@ Subject length lower bound = 4
 /abcd/I,no_start_optimize
 Capture group count = 0
 Options: no_start_optimize
+Optimizations: auto_possess,dotstar_anchor
 
 /(|ab)*?d/I
 Capture group count = 1
@@ -13616,6 +13617,7 @@ Subject length lower bound = 1
 /(|ab)*?d/I,no_start_optimize
 Capture group count = 1
 Options: no_start_optimize
+Optimizations: auto_possess,dotstar_anchor
    abd
  0: abd
  1: ab
@@ -13887,6 +13889,7 @@ Subject length lower bound = 3
 Capture group count = 0
 Compile options: no_dotstar_anchor
 Overall options: anchored no_dotstar_anchor
+Optimizations: auto_possess,start_optimize
 First code unit = 'a'
 Subject length lower bound = 3
 
@@ -13908,6 +13911,7 @@ No match
 /.*\d/info,no_dotstar_anchor,auto_callout
 Capture group count = 0
 Options: auto_callout no_dotstar_anchor
+Optimizations: auto_possess,start_optimize
 Subject length lower bound = 1
 \= Expect no match
     aaa
@@ -13935,12 +13939,12 @@ Subject length lower bound = 1
 /.*\d/dotall,no_dotstar_anchor,info
 Capture group count = 0
 Options: dotall no_dotstar_anchor
+Optimizations: auto_possess,start_optimize
 Subject length lower bound = 1
 
 /(*NO_DOTSTAR_ANCHOR)(?s).*\d/info
 Capture group count = 0
-Compile options: <none>
-Overall options: no_dotstar_anchor
+Optimizations: auto_possess,start_optimize
 Subject length lower bound = 1
 
 '^(?:(a)|b)(?(1)A|B)'
@@ -18049,12 +18053,14 @@ Subject length lower bound = 1
 /a?(?=b(*COMMIT)c|)d/I,no_start_optimize
 Capture group count = 0
 Options: no_start_optimize
+Optimizations: auto_possess,dotstar_anchor
     bd
 No match
 
 /(?=b(*COMMIT)c|)d/I,no_start_optimize
 Capture group count = 0
 Options: no_start_optimize
+Optimizations: auto_possess,dotstar_anchor
     bd
 No match
 

--- a/testdata/testoutput5
+++ b/testdata/testoutput5
@@ -474,6 +474,7 @@ Subject length lower bound = 0
 Capture group count = 0
 Compile options: no_start_optimize utf
 Overall options: anchored no_start_optimize utf
+Optimizations: auto_possess,dotstar_anchor
 
 /()()()()()()()()()()
  ()()()()()()()()()()

--- a/testdata/testoutput6
+++ b/testdata/testoutput6
@@ -6860,6 +6860,7 @@ No match
 /(abc|def|xyz)/I,no_start_optimize
 Capture group count = 1
 Options: no_start_optimize
+Optimizations: auto_possess,dotstar_anchor
     terhjk;abcdaadsfe
  0: abc
     the quick xyz brown fox


### PR DESCRIPTION
Minimize pcre2test output, and will be more relevant when new API is actually used.