### PR TITLE
Make pcre2_set_optimize() consistent with PCRE2_LITERAL

### DIFF
--- a/doc/html/pcre2_set_optimize.html
+++ b/doc/html/pcre2_set_optimize.html
@@ -1,0 +1,47 @@
+<html>
+<head>
+<title>pcre2_set_optimize specification</title>
+</head>
+<body bgcolor="#FFFFFF" text="#00005A" link="#0066FF" alink="#3399FF" vlink="#2222BB">
+<h1>pcre2_set_optimize man page</h1>
+<p>
+Return to the <a href="index.html">PCRE2 index page</a>.
+</p>
+<p>
+This page is part of the PCRE2 HTML documentation. It was generated
+automatically from the original man page. If there is any nonsense in it,
+please consult the man page, in case the conversion went wrong.
+<br>
+<br><b>
+SYNOPSIS
+</b><br>
+<P>
+<b>#include &#60;pcre2.h&#62;</b>
+</P>
+<P>
+<b>int pcre2_set_optimize(pcre2_compile_context *<i>ccontext</i>,</b>
+<b>  uint32_t <i>directive</i>);</b>
+</P>
+<br><b>
+DESCRIPTION
+</b><br>
+<P>
+This function controls which performance optimizations will be applied
+by <b>pcre2_compile</b>. It can be called multiple times with the same compile
+context; the effects are cumulative, with the effects of later calls taking
+precedence over earlier ones.
+</P>
+<P>
+The result is zero for success, PCRE2_ERROR_NULL if <i>ccontext</i> is NULL,
+or PCRE2_ERROR_BADOPTION if <i>directive</i> is unknown. This can be used to
+detect when the available version of PCRE2 does not implement a certain
+optimization.
+</P>
+<P>
+There is a complete description of the PCRE2 native API, including all
+permitted values for the <i>directive</i> parameter of <b>pcre2_set_optimize</b>,
+in the
+<a href="pcre2api.html"><b>pcre2api</b></a>
+page.<p>
+Return to the <a href="index.html">PCRE2 index page</a>.
+</p>

--- a/doc/html/pcre2api.html
+++ b/doc/html/pcre2api.html
@@ -179,6 +179,10 @@ document for an overview of all the PCRE2 documentation.
 <br>
 <b>int pcre2_set_compile_recursion_guard(pcre2_compile_context *<i>ccontext</i>,</b>
 <b>  int (*<i>guard_function</i>)(uint32_t, void *), void *<i>user_data</i>);</b>
+<br>
+<br>
+<b>int pcre2_set_optimize(pcre2_compile_context *<i>ccontext</i>,</b>
+<b>  uint32_t <i>directive</i>);</b>
 </P>
 <br><a name="SEC5" href="#TOC1">PCRE2 NATIVE API MATCH CONTEXT FUNCTIONS</a><br>
 <P>
@@ -808,6 +812,7 @@ following compile-time parameters:
   The compile time nested parentheses limit
   The maximum length of the pattern string
   The extra options bits (none set by default)
+  Which performance optimizations the compiler should apply
 </pre>
 A compile context is also required if you are using custom memory management.
 If none of these apply, just pass NULL as the context argument of
@@ -952,6 +957,110 @@ The first argument to the callout function gives the current depth of
 nesting, and the second is user data that is set up by the last argument of
 <b>pcre2_set_compile_recursion_guard()</b>. The callout function should return
 zero if all is well, or non-zero to force an error.
+<br>
+<br>
+<b>int pcre2_set_optimize(pcre2_compile_context *<i>ccontext</i>,</b>
+<b>  uint32_t <i>directive</i>);</b>
+<br>
+<br>
+PCRE2 can apply various performance optimizations during compilation, in order
+to make matching faster. For example, the compiler might convert some regex
+constructs into an equivalent construct which <b>pcre2_match()</b> can execute
+faster. By default, all available optimizations are enabled. However, in rare
+cases, one might wish to disable specific optimizations. For example, if it is
+known that some optimizations cannot benefit a certain regex, it might be
+desirable to disable them, in order to speed up compilation.
+</P>
+<P>
+The permitted values of <i>directive</i> are as follows:
+<pre>
+  PCRE2_OPTIMIZATION_NONE
+</pre>
+Disable all optional performance optimizations.
+<pre>
+  PCRE2_OPTIMIZATION_FULL
+</pre>
+Enable all optional performance optimizations. This is the default value.
+<pre>
+  PCRE2_AUTO_POSSESS
+  PCRE2_AUTO_POSSESS_OFF
+</pre>
+Enable/disable "auto-possessification" of variable quantifiers such as * and +.
+This optimization, for example, turns a+b into a++b in order to avoid
+backtracks into a+ that can never be successful. However, if callouts are in
+use, auto-possessification means that some callouts are never taken. You can
+disable this optimization if you want the matching functions to do a full,
+unoptimized search and run all the callouts.
+<pre>
+  PCRE2_DOTSTAR_ANCHOR
+  PCRE2_DOTSTAR_ANCHOR_OFF
+</pre>
+Enable/disable an optimization that is applied when .* is the first significant
+item in a top-level branch of a pattern, and all the other branches also start
+with .* or with \A or \G or ^. Such a pattern is automatically anchored if
+PCRE2_DOTALL is set for all the .* items and PCRE2_MULTILINE is not set for any
+^ items. Otherwise, the fact that any match must start either at the start of
+the subject or following a newline is remembered. Like other optimizations,
+this can cause callouts to be skipped.
+</P>
+<P>
+Dotstar anchor optimization is automatically disabled for .* if it is inside an
+atomic group or a capture group that is the subject of a backreference, or if
+the pattern contains (*PRUNE) or (*SKIP).
+<pre>
+  PCRE2_START_OPTIMIZE
+  PCRE2_START_OPTIMIZE_OFF
+</pre>
+Enable/disable optimizations which cause matching functions to scan the subject
+string for specific code unit values before attempting a match. For example, if
+it is known that an unanchored match must start with a specific value, the
+matching code searches the subject for that value, and fails immediately if it
+cannot find it, without actually running the main matching function. This means
+that a special item such as (*COMMIT) at the start of a pattern is not
+considered until after a suitable starting point for the match has been found.
+Also, when callouts or (*MARK) items are in use, these "start-up" optimizations
+can cause them to be skipped if the pattern is never actually used. The start-up
+optimizations are in effect a pre-scan of the subject that takes place before
+the pattern is run.
+</P>
+<P>
+Disabling start-up optimizations ensures that in cases where the result is "no
+match", the callouts do occur, and that items such as (*COMMIT) and (*MARK) are
+considered at every possible starting position in the subject string.
+</P>
+<P>
+Disabling start-up optimizations may change the outcome of a matching operation.
+Consider the pattern
+<pre>
+  (*COMMIT)ABC
+</pre>
+When this is compiled, PCRE2 records the fact that a match must start with the
+character "A". Suppose the subject string is "DEFABC". The start-up
+optimization scans along the subject, finds "A" and runs the first match
+attempt from there. The (*COMMIT) item means that the pattern must match the
+current starting position, which in this case, it does. However, if the same
+match is run without start-up optimizations, the initial scan along the subject
+string does not happen. The first match attempt is run starting from "D" and
+when this fails, (*COMMIT) prevents any further matches being tried, so the
+overall result is "no match".
+</P>
+<P>
+Another start-up optimization makes use of a minimum length for a matching
+subject, which is recorded when possible. Consider the pattern
+<pre>
+  (*MARK:1)B(*MARK:2)(X|Y)
+</pre>
+The minimum length for a match is two characters. If the subject is "XXBB", the
+"starting character" optimization skips "XX", then tries to match "BB", which
+is long enough. In the process, (*MARK:2) is encountered and remembered. When
+the match attempt fails, the next "B" is found, but there is only one character
+left, so there are no more attempts, and "no match" is returned with the "last
+mark seen" set to "2". Without start-up optimizations, however, matches are
+tried at every possible starting position, including at the end of the subject,
+where (*MARK:1) is encountered, but there is no "B", so the "last mark seen"
+that is returned is "1". In this case, the optimizations do not affect the
+overall match result, which is still "no match", but they do affect the
+auxiliary information that is returned.
 <a name="matchcontext"></a></P>
 <br><b>
 The match context
@@ -1807,85 +1916,57 @@ though the reference can be by name or by number.
 <pre>
   PCRE2_NO_AUTO_POSSESS
 </pre>
-If this option is set, it disables "auto-possessification", which is an
-optimization that, for example, turns a+b into a++b in order to avoid
+If this (deprecated) option is set, it disables "auto-possessification", which
+is an optimization that, for example, turns a+b into a++b in order to avoid
 backtracks into a+ that can never be successful. However, if callouts are in
 use, auto-possessification means that some callouts are never taken. You can
 set this option if you want the matching functions to do a full unoptimized
 search and run all the callouts, but it is mainly provided for testing
 purposes.
+</P>
+<P>
+If a compile context is available, it is recommended to use
+<b>pcre2_set_optimize()</b> with the <i>directive</i> PCRE2_AUTO_POSSESS_OFF rather
+than the compile option PCRE2_NO_AUTO_POSSESS. Note that PCRE2_NO_AUTO_POSSESS
+takes precedence over the <b>pcre2_set_optimize()</b> optimization directives
+PCRE2_AUTO_POSSESS and PCRE2_AUTO_POSSESS_OFF.
 <pre>
   PCRE2_NO_DOTSTAR_ANCHOR
 </pre>
-If this option is set, it disables an optimization that is applied when .* is
-the first significant item in a top-level branch of a pattern, and all the
-other branches also start with .* or with \A or \G or ^. The optimization is
-automatically disabled for .* if it is inside an atomic group or a capture
-group that is the subject of a backreference, or if the pattern contains
-(*PRUNE) or (*SKIP). When the optimization is not disabled, such a pattern is
-automatically anchored if PCRE2_DOTALL is set for all the .* items and
-PCRE2_MULTILINE is not set for any ^ items. Otherwise, the fact that any match
-must start either at the start of the subject or following a newline is
+If this (deprecated) option is set, it disables an optimization that is applied
+when .* is the first significant item in a top-level branch of a pattern, and
+all the other branches also start with .* or with \A or \G or ^. The
+optimization is automatically disabled for .* if it is inside an atomic group
+or a capture group that is the subject of a backreference, or if the pattern
+contains (*PRUNE) or (*SKIP). When the optimization is not disabled, such a
+pattern is automatically anchored if PCRE2_DOTALL is set for all the .* items
+and PCRE2_MULTILINE is not set for any ^ items. Otherwise, the fact that any
+match must start either at the start of the subject or following a newline is
 remembered. Like other optimizations, this can cause callouts to be skipped.
+(If a compile context is available, it is recommended to use
+<b>pcre2_set_optimize()</b> with the <i>directive</i> PCRE2_DOTSTAR_ANCHOR_OFF
+instead.)
 <pre>
   PCRE2_NO_START_OPTIMIZE
 </pre>
 This is an option whose main effect is at matching time. It does not change
 what <b>pcre2_compile()</b> generates, but it does affect the output of the JIT
-compiler.
+compiler. Setting this option is equivalent to calling <b>pcre2_set_optimize()</b>
+with the <i>directive</i> parameter set to PCRE2_START_OPTIMIZE_OFF.
 </P>
 <P>
 There are a number of optimizations that may occur at the start of a match, in
 order to speed up the process. For example, if it is known that an unanchored
 match must start with a specific code unit value, the matching code searches
 the subject for that value, and fails immediately if it cannot find it, without
-actually running the main matching function. This means that a special item
-such as (*COMMIT) at the start of a pattern is not considered until after a
-suitable starting point for the match has been found. Also, when callouts or
-(*MARK) items are in use, these "start-up" optimizations can cause them to be
-skipped if the pattern is never actually used. The start-up optimizations are
+actually running the main matching function. The start-up optimizations are
 in effect a pre-scan of the subject that takes place before the pattern is run.
 </P>
 <P>
-The PCRE2_NO_START_OPTIMIZE option disables the start-up optimizations,
-possibly causing performance to suffer, but ensuring that in cases where the
-result is "no match", the callouts do occur, and that items such as (*COMMIT)
-and (*MARK) are considered at every possible starting position in the subject
-string.
-</P>
-<P>
-Setting PCRE2_NO_START_OPTIMIZE may change the outcome of a matching operation.
-Consider the pattern
-<pre>
-  (*COMMIT)ABC
-</pre>
-When this is compiled, PCRE2 records the fact that a match must start with the
-character "A". Suppose the subject string is "DEFABC". The start-up
-optimization scans along the subject, finds "A" and runs the first match
-attempt from there. The (*COMMIT) item means that the pattern must match the
-current starting position, which in this case, it does. However, if the same
-match is run with PCRE2_NO_START_OPTIMIZE set, the initial scan along the
-subject string does not happen. The first match attempt is run starting from
-"D" and when this fails, (*COMMIT) prevents any further matches being tried, so
-the overall result is "no match".
-</P>
-<P>
-As another start-up optimization makes use of a minimum length for a matching
-subject, which is recorded when possible. Consider the pattern
-<pre>
-  (*MARK:1)B(*MARK:2)(X|Y)
-</pre>
-The minimum length for a match is two characters. If the subject is "XXBB", the
-"starting character" optimization skips "XX", then tries to match "BB", which
-is long enough. In the process, (*MARK:2) is encountered and remembered. When
-the match attempt fails, the next "B" is found, but there is only one character
-left, so there are no more attempts, and "no match" is returned with the "last
-mark seen" set to "2". If NO_START_OPTIMIZE is set, however, matches are tried
-at every possible starting position, including at the end of the subject, where
-(*MARK:1) is encountered, but there is no "B", so the "last mark seen" that is
-returned is "1". In this case, the optimizations do not affect the overall
-match result, which is still "no match", but they do affect the auxiliary
-information that is returned.
+Disabling the start-up optimizations may cause performance to suffer. However,
+this may be desirable for patterns which contain callouts or items such as
+(*COMMIT) and (*MARK). See the above description of PCRE2_START_OPTIMIZE_OFF
+for further details.
 <pre>
   PCRE2_NO_UTF_CHECK
 </pre>
@@ -2312,6 +2393,7 @@ following are true:
   PCRE2_DOTALL is in force for .*
   Neither (*PRUNE) nor (*SKIP) appears in the pattern
   PCRE2_NO_DOTSTAR_ANCHOR is not set
+  Dotstar anchoring has not been disabled with PCRE2_DOTSTAR_ANCHOR_OFF
 </pre>
 For patterns that are auto-anchored, the PCRE2_ANCHORED bit is set in the
 options returned for PCRE2_INFO_ALLOPTIONS.

--- a/doc/html/pcre2pattern.html
+++ b/doc/html/pcre2pattern.html
@@ -142,7 +142,8 @@ Disabling auto-possessification
 </b><br>
 <P>
 If a pattern starts with (*NO_AUTO_POSSESS), it has the same effect as setting
-the PCRE2_NO_AUTO_POSSESS option. This stops PCRE2 from making quantifiers
+the PCRE2_NO_AUTO_POSSESS option, or calling <b>pcre2_set_optimize()</b> with
+a PCRE2_AUTO_POSSESS_OFF directive. This stops PCRE2 from making quantifiers
 possessive when what follows cannot match the repeated item. For example, by
 default a+b is treated as a++b. For more details, see the
 <a href="pcre2api.html"><b>pcre2api</b></a>
@@ -153,8 +154,9 @@ Disabling start-up optimizations
 </b><br>
 <P>
 If a pattern starts with (*NO_START_OPT), it has the same effect as setting the
-PCRE2_NO_START_OPTIMIZE option. This disables several optimizations for quickly
-reaching "no match" results. For more details, see the
+PCRE2_NO_START_OPTIMIZE option, or calling <b>pcre2_set_optimize()</b> with
+a PCRE2_START_OPTIMIZE_OFF directive. This disables several optimizations for
+quickly reaching "no match" results. For more details, see the
 <a href="pcre2api.html"><b>pcre2api</b></a>
 documentation.
 </P>
@@ -163,7 +165,8 @@ Disabling automatic anchoring
 </b><br>
 <P>
 If a pattern starts with (*NO_DOTSTAR_ANCHOR), it has the same effect as
-setting the PCRE2_NO_DOTSTAR_ANCHOR option. This disables optimizations that
+setting the PCRE2_NO_DOTSTAR_ANCHOR option, or calling <b>pcre2_set_optimize()</b>
+with a PCRE2_DOTSTAR_ANCHOR_OFF directive. This disables optimizations that
 apply to patterns whose top-level branches all start with .* (match any number
 of arbitrary characters). For more details, see the
 <a href="pcre2api.html"><b>pcre2api</b></a>
@@ -2145,8 +2148,9 @@ one succeeds. Consider this pattern:
   (?&#62;.*?a)b
 </pre>
 It matches "ab" in the subject "aab". The use of the backtracking control verbs
-(*PRUNE) and (*SKIP) also disable this optimization, and there is an option,
-PCRE2_NO_DOTSTAR_ANCHOR, to do so explicitly.
+(*PRUNE) and (*SKIP) also disable this optimization. To do so explicitly,
+either pass the compile option PCRE2_NO_DOTSTAR_ANCHOR, or call
+<b>pcre2_set_optimize()</b> with a PCRE2_DOTSTAR_ANCHOR_OFF directive.
 </P>
 <P>
 When a capture group is repeated, the value captured is the substring that
@@ -2243,8 +2247,9 @@ package, and PCRE1 copied it from there. It found its way into Perl at release
 PCRE2 has an optimization that automatically "possessifies" certain simple
 pattern constructs. For example, the sequence A+B is treated as A++B because
 there is no point in backtracking into a sequence of A's when B must follow.
-This feature can be disabled by the PCRE2_NO_AUTOPOSSESS option, or starting
-the pattern with (*NO_AUTO_POSSESS).
+This feature can be disabled by the PCRE2_NO_AUTO_POSSESS option, by calling
+<b>pcre2_set_optimize()</b> with a PCRE2_AUTO_POSSESS_OFF directive, or by
+starting the pattern with (*NO_AUTO_POSSESS).
 </P>
 <P>
 When a pattern contains an unlimited repeat inside a group that can itself be
@@ -3464,9 +3469,9 @@ minimum length of matching subject, or that a particular character must be
 present. When one of these optimizations bypasses the running of a match, any
 included backtracking verbs will not, of course, be processed. You can suppress
 the start-of-match optimizations by setting the PCRE2_NO_START_OPTIMIZE option
-when calling <b>pcre2_compile()</b>, or by starting the pattern with
-(*NO_START_OPT). There is more discussion of this option in the section
-entitled
+when calling <b>pcre2_compile()</b>, by calling <b>pcre2_set_optimize()</b> with a
+PCRE_START_OPTIMIZE_OFF directive, or by starting the pattern with (*NO_START_OPT).
+There is more discussion of this option in the section entitled
 <a href="pcre2api.html#compiling">"Compiling a pattern"</a>
 in the
 <a href="pcre2api.html"><b>pcre2api</b></a>
@@ -3597,7 +3602,8 @@ attempts starting at "P" and then with an empty string do not get as far as the
 </P>
 <P>
 If you are interested in (*MARK) values after failed matches, you should
-probably set the PCRE2_NO_START_OPTIMIZE option
+probably either set the PCRE2_NO_START_OPTIMIZE option or call
+<b>pcre2_set_optimize()</b> with a PCRE2_START_OPTIMIZE_OFF directive
 <a href="#nooptimize">(see above)</a>
 to ensure that the match is always attempted.
 </P>

--- a/doc/html/pcre2test.html
+++ b/doc/html/pcre2test.html
@@ -681,6 +681,23 @@ notation. Otherwise, those less than 0x100 are output in hex without the curly
 brackets. Setting <b>utf</b> in 16-bit or 32-bit mode also causes pattern and
 subject strings to be translated to UTF-16 or UTF-32, respectively, before
 being passed to library functions.
+<br>
+<br>
+The following modifiers enable or disable performance optimizations by
+calling <b>pcre2_set_optimize()</b> before invoking the regex compiler.
+<pre>
+      optimization_full      enable all optional optimizations
+      optimization_none      disable all optional optimizations
+      auto_possess           auto-possessify variable quantifiers
+      auto_possess_off       don't auto-possessify variable quantifiers
+      dotstar_anchor         anchor patterns starting with .*
+      dotstar_anchor_off     don't anchor patterns starting with .*
+      start_optimize         enable pre-scan of subject string
+      start_optimize_off     disable pre-scan of subject string
+</pre>
+See the
+<a href="pcre2_set_optimize.html"><b>pcre2_set_optimize</b></a>
+documentation for details on these optimizations.
 <a name="controlmodifiers"></a></P>
 <br><b>
 Setting compilation controls

--- a/doc/pcre2.txt
+++ b/doc/pcre2.txt
@@ -296,6 +296,9 @@ PCRE2 NATIVE API COMPILE CONTEXT FUNCTIONS
        int pcre2_set_compile_recursion_guard(pcre2_compile_context *ccontext,
          int (*guard_function)(uint32_t, void *), void *user_data);
 
+       int pcre2_set_optimize(pcre2_compile_context *ccontext,
+         uint32_t directive);
+
 
 PCRE2 NATIVE API MATCH CONTEXT FUNCTIONS
 
@@ -977,6 +980,110 @@ PCRE2 CONTEXTS
        nesting, and the second is user data that is set up by the  last  argu-
        ment   of  pcre2_set_compile_recursion_guard().  The  callout  function
        should return zero if all is well, or non-zero to force an error.
+
+       int pcre2_set_optimize(pcre2_compile_context *ccontext,
+         uint32_t directive);
+
+       PCRE2 can apply various performance optimizations  during  compilation,
+       in  order to make matching faster. For example, the compiler might con‐
+       vert  some  regex  constructs  into  an  equivalent   construct   which
+       pcre2_match()  can  execute faster. By default, all available optimiza‐
+       tions are enabled. However, in rare cases, one might  wish  to  disable
+       specific optimizations. For example, if it is known that some optimiza‐
+       tions cannot benefit a certain regex, it might be desirable to  disable
+       them, in order to speed up compilation.
+
+       The permitted values of directive are as follows:
+
+         PCRE2_OPTIMIZATION_NONE
+
+       Disable all optional performance optimizations.
+
+         PCRE2_OPTIMIZATION_FULL
+
+       Enable  all  optional  performance  optimizations.  This is the default
+       value.
+
+         PCRE2_AUTO_POSSESS
+         PCRE2_AUTO_POSSESS_OFF
+
+       Enable/disable "auto-possessification" of variable quantifiers such  as
+       *  and +.  This optimization, for example, turns a+b into a++b in order
+       to avoid backtracks into a+ that can never be successful.  However,  if
+       callouts are in use, auto-possessification means that some callouts are
+       never taken. You can disable this optimization if you want the matching
+       functions to do a full, unoptimized search and run all the callouts.
+
+         PCRE2_DOTSTAR_ANCHOR
+         PCRE2_DOTSTAR_ANCHOR_OFF
+
+       Enable/disable  an  optimization  that  is applied when .* is the first
+       significant item in a top-level branch of a pattern, and all the  other
+       branches  also  start  with .* or with \A or \G or ^. Such a pattern is
+       automatically anchored if PCRE2_DOTALL is set for all the .* items  and
+       PCRE2_MULTILINE  is  not  set for any ^ items. Otherwise, the fact that
+       any match must start either at the start of the subject or following  a
+       newline  is  remembered. Like other optimizations, this can cause call‐
+       outs to be skipped.
+
+       Dotstar anchor optimization is automatically disabled for .* if  it  is
+       inside  an  atomic  group  or  a capture group that is the subject of a
+       backreference, or if the pattern contains (*PRUNE) or (*SKIP).
+
+         PCRE2_START_OPTIMIZE
+         PCRE2_START_OPTIMIZE_OFF
+
+       Enable/disable optimizations which cause matching functions to scan the
+       subject string for specific code unit values before attempting a match.
+       For example, if it is known that an unanchored match must start with  a
+       specific  value, the matching code searches the subject for that value,
+       and fails immediately if it cannot find it,  without  actually  running
+       the  main  matching  function.  This  means that a special item such as
+       (*COMMIT) at the start of a pattern is not  considered  until  after  a
+       suitable starting point for the match has been found.  Also, when call‐
+       outs or (*MARK) items are in use, these  "start-up"  optimizations  can
+       cause  them  to  be  skipped if the pattern is never actually used. The
+       start-up optimizations are in effect a pre-scan  of  the  subject  that
+       takes place before the pattern is run.
+
+       Disabling start-up optimizations ensures that in cases where the result
+       is "no match", the callouts do occur, and that items such as  (*COMMIT)
+       and  (*MARK)  are considered at every possible starting position in the
+       subject string.
+
+       Disabling start-up optimizations may change the outcome of  a  matching
+       operation.  Consider the pattern
+
+         (*COMMIT)ABC
+
+       When  this  is compiled, PCRE2 records the fact that a match must start
+       with the character "A". Suppose the subject  string  is  "DEFABC".  The
+       start-up  optimization  scans along the subject, finds "A" and runs the
+       first match attempt from there. The (*COMMIT) item means that the  pat‐
+       tern  must  match the current starting position, which in this case, it
+       does. However, if the same match is run without start-up optimizations,
+       the  initial  scan  along the subject string does not happen. The first
+       match attempt is run starting from "D" and when this  fails,  (*COMMIT)
+       prevents  any further matches being tried, so the overall result is "no
+       match".
+
+       Another start-up optimization makes use  of  a  minimum  length  for  a
+       matching subject, which is recorded when possible. Consider the pattern
+
+         (*MARK:1)B(*MARK:2)(X|Y)
+
+       The  minimum  length  for  a match is two characters. If the subject is
+       "XXBB", the "starting character" optimization skips "XX", then tries to
+       match  "BB", which is long enough. In the process, (*MARK:2) is encoun‐
+       tered and remembered. When the match attempt fails,  the  next  "B"  is
+       found,  but  there is only one character left, so there are no more at‐
+       tempts, and "no match" is returned with the "last  mark  seen"  set  to
+       "2".  Without start-up optimizations, however, matches are tried at ev‐
+       ery possible starting position, including at the end  of  the  subject,
+       where  (*MARK:1) is encountered, but there is no "B", so the "last mark
+       seen" that is returned is "1". In this case, the optimizations  do  not
+       affect the overall match result, which is still "no match", but they do
+       affect the auxiliary information that is returned.
 
    The match context
 
@@ -1775,86 +1882,56 @@ COMPILING A PATTERN
 
          PCRE2_NO_AUTO_POSSESS
 
-       If this option is set, it disables "auto-possessification", which is an
-       optimization that, for example, turns a+b into a++b in order  to  avoid
-       backtracks  into  a+ that can never be successful. However, if callouts
-       are in use, auto-possessification means that some  callouts  are  never
-       taken. You can set this option if you want the matching functions to do
-       a  full  unoptimized  search and run all the callouts, but it is mainly
-       provided for testing purposes.
+       If this (deprecated) option is  set,  it  disables  "auto-possessifica‐
+       tion",  which is an optimization that, for example, turns a+b into a++b
+       in order to avoid backtracks into a+ that can never be successful. How‐
+       ever,  if  callouts  are  in use, auto-possessification means that some
+       callouts are never taken. You can set  this  option  if  you  want  the
+       matching  functions  to  do  a  full unoptimized search and run all the
+       callouts, but it is mainly provided for testing purposes.
+
+       If  a  compile  context  is  available,  it  is  recommended   to   use
+       pcre2_set_optimize()  with  the directive PCRE2_AUTO_POSSESS_OFF rather
+       than   the   compile   option    PCRE2_NO_AUTO_POSSESS.    Note    that
+       PCRE2_NO_AUTO_POSSESS  takes  precedence  over the pcre2_set_optimize()
+       optimization directives PCRE2_AUTO_POSSESS and PCRE2_AUTO_POSSESS_OFF.
 
          PCRE2_NO_DOTSTAR_ANCHOR
 
-       If this option is set, it disables an optimization that is applied when
-       .* is the first significant item in a top-level branch  of  a  pattern,
-       and  all  the  other branches also start with .* or with \A or \G or ^.
-       The optimization is automatically disabled for .* if it  is  inside  an
-       atomic group or a capture group that is the subject of a backreference,
-       or  if  the pattern contains (*PRUNE) or (*SKIP). When the optimization
-       is  not  disabled,  such  a  pattern  is  automatically   anchored   if
+       If this (deprecated) option is set, it disables an optimization that is
+       applied when .* is the first significant item in a top-level branch  of
+       a  pattern, and all the other branches also start with .* or with \A or
+       \G or ^. The optimization is automatically disabled for .* if it is in‐
+       side  an atomic group or a capture group that is the subject of a back‐
+       reference, or if the pattern contains (*PRUNE) or (*SKIP). When the op‐
+       timization is not disabled, such a pattern is automatically anchored if
        PCRE2_DOTALL is set for all the .* items and PCRE2_MULTILINE is not set
-       for  any  ^ items. Otherwise, the fact that any match must start either
-       at the start of the subject or following a newline is remembered.  Like
-       other optimizations, this can cause callouts to be skipped.
+       for any ^ items. Otherwise, the fact that any match must  start  either
+       at  the start of the subject or following a newline is remembered. Like
+       other optimizations, this can cause callouts to be skipped.  (If a com‐
+       pile  context  is  available,  it is recommended to use pcre2_set_opti�‐
+       mize() with the directive PCRE2_DOTSTAR_ANCHOR_OFF instead.)
 
          PCRE2_NO_START_OPTIMIZE
 
-       This  is  an  option whose main effect is at matching time. It does not
+       This is an option whose main effect is at matching time.  It  does  not
        change what pcre2_compile() generates, but it does affect the output of
-       the JIT compiler.
+       the  JIT  compiler.  Setting  this  option  is  equivalent  to  calling
+       pcre2_set_optimize()    with    the    directive   parameter   set   to
+       PCRE2_START_OPTIMIZE_OFF.
 
        There are a number of optimizations that may occur at the  start  of  a
        match,  in  order  to speed up the process. For example, if it is known
        that an unanchored match must start with a specific  code  unit  value,
-       the  matching code searches the subject for that value, and fails imme-
-       diately if it cannot find it, without actually running the main  match-
-       ing  function.  This means that a special item such as (*COMMIT) at the
-       start of a pattern is not considered until after  a  suitable  starting
-       point  for  the  match  has  been found. Also, when callouts or (*MARK)
-       items are in use, these "start-up" optimizations can cause them  to  be
-       skipped  if  the pattern is never actually used. The start-up optimiza-
-       tions are in effect a pre-scan of the subject that takes  place  before
-       the pattern is run.
+       the  matching code searches the subject for that value, and fails imme‐
+       diately if it cannot find it, without actually running the main  match‐
+       ing  function.  The  start-up optimizations are in effect a pre-scan of
+       the subject that takes place before the pattern is run.
 
-       The PCRE2_NO_START_OPTIMIZE option disables the start-up optimizations,
-       possibly  causing  performance  to  suffer,  but ensuring that in cases
-       where the result is "no match", the callouts do occur, and  that  items
-       such as (*COMMIT) and (*MARK) are considered at every possible starting
-       position in the subject string.
-
-       Setting  PCRE2_NO_START_OPTIMIZE  may  change the outcome of a matching
-       operation.  Consider the pattern
-
-         (*COMMIT)ABC
-
-       When this is compiled, PCRE2 records the fact that a match  must  start
-       with  the  character  "A".  Suppose the subject string is "DEFABC". The
-       start-up optimization scans along the subject, finds "A" and  runs  the
-       first  match attempt from there. The (*COMMIT) item means that the pat-
-       tern must match the current starting position, which in this  case,  it
-       does.  However,  if  the same match is run with PCRE2_NO_START_OPTIMIZE
-       set, the initial scan along the subject string  does  not  happen.  The
-       first  match  attempt  is  run  starting  from "D" and when this fails,
-       (*COMMIT) prevents any further matches being tried, so the overall  re-
-       sult is "no match".
-
-       As  another  start-up  optimization makes use of a minimum length for a
-       matching subject, which is recorded when possible. Consider the pattern
-
-         (*MARK:1)B(*MARK:2)(X|Y)
-
-       The minimum length for a match is two characters.  If  the  subject  is
-       "XXBB", the "starting character" optimization skips "XX", then tries to
-       match  "BB", which is long enough. In the process, (*MARK:2) is encoun-
-       tered and remembered. When the match attempt fails,  the  next  "B"  is
-       found,  but  there is only one character left, so there are no more at-
-       tempts, and "no match" is returned with the "last  mark  seen"  set  to
-       "2".  If  NO_START_OPTIMIZE is set, however, matches are tried at every
-       possible starting position, including at the end of the subject,  where
-       (*MARK:1)  is encountered, but there is no "B", so the "last mark seen"
-       that is returned is "1". In this case, the optimizations do not  affect
-       the overall match result, which is still "no match", but they do affect
-       the auxiliary information that is returned.
+       Disabling the start-up optimizations may cause performance  to  suffer.
+       However,  this  may be desirable for patterns which contain callouts or
+       items such as (*COMMIT) and  (*MARK).  See  the  above  description  of
+       PCRE2_START_OPTIMIZE_OFF for further details.
 
          PCRE2_NO_UTF_CHECK
 
@@ -2261,6 +2338,7 @@ INFORMATION ABOUT A COMPILED PATTERN
          PCRE2_DOTALL is in force for .*
          Neither (*PRUNE) nor (*SKIP) appears in the pattern
          PCRE2_NO_DOTSTAR_ANCHOR is not set
+         Dotstar anchoring has not been disabled with PCRE2_DOTSTAR_ANCHOR_OFF
 
        For patterns that are auto-anchored, the PCRE2_ANCHORED bit is  set  in
        the options returned for PCRE2_INFO_ALLOPTIONS.
@@ -8413,41 +8491,42 @@ REPETITION
        words, it inverts the default behaviour.
 
        When  a  parenthesized  group is quantified with a minimum repeat count
-       that is greater than 1 or with a limited maximum, more  memory  is  re-
-       quired for the compiled pattern, in proportion to the size of the mini-
+       that is greater than 1 or with a limited maximum, more  memory  is  re‐
+       quired for the compiled pattern, in proportion to the size of the mini‐
        mum or maximum.
 
-       If  a  pattern  starts  with  .*  or  .{0,} and the PCRE2_DOTALL option
-       (equivalent to Perl's /s) is set, thus allowing the dot to  match  new-
-       lines,  the  pattern  is  implicitly anchored, because whatever follows
-       will be tried against every character position in the  subject  string,
-       so  there is no point in retrying the overall match at any position af-
-       ter the first. PCRE2 normally treats such a pattern as though  it  were
+       If a pattern starts with  .*  or  .{0,}  and  the  PCRE2_DOTALL  option
+       (equivalent  to  Perl's /s) is set, thus allowing the dot to match new‐
+       lines, the pattern is implicitly  anchored,  because  whatever  follows
+       will  be  tried against every character position in the subject string,
+       so there is no point in retrying the overall match at any position  af‐
+       ter  the  first. PCRE2 normally treats such a pattern as though it were
        preceded by \A.
 
-       In  cases  where  it  is known that the subject string contains no new-
-       lines, it is worth setting PCRE2_DOTALL in order to obtain  this  opti-
+       In cases where it is known that the subject  string  contains  no  new‐
+       lines,  it  is worth setting PCRE2_DOTALL in order to obtain this opti‐
        mization, or alternatively, using ^ to indicate anchoring explicitly.
 
-       However,  there  are  some cases where the optimization cannot be used.
-       When .*  is inside capturing parentheses that  are  the  subject  of  a
-       backreference  elsewhere  in the pattern, a match at the start may fail
+       However, there are some cases where the optimization  cannot  be  used.
+       When  .*   is  inside  capturing  parentheses that are the subject of a
+       backreference elsewhere in the pattern, a match at the start  may  fail
        where a later one succeeds. Consider, for example:
 
          (.*)abc\1
 
-       If the subject is "xyz123abc123" the match point is the fourth  charac-
+       If  the subject is "xyz123abc123" the match point is the fourth charac‐
        ter. For this reason, such a pattern is not implicitly anchored.
 
-       Another  case where implicit anchoring is not applied is when the lead-
-       ing .* is inside an atomic group. Once again, a match at the start  may
+       Another case where implicit anchoring is not applied is when the  lead‐
+       ing  .* is inside an atomic group. Once again, a match at the start may
        fail where a later one succeeds. Consider this pattern:
 
          (?>.*?a)b
 
-       It  matches "ab" in the subject "aab". The use of the backtracking con-
-       trol verbs (*PRUNE) and (*SKIP) also  disable  this  optimization,  and
-       there is an option, PCRE2_NO_DOTSTAR_ANCHOR, to do so explicitly.
+       It matches "ab" in the subject "aab". The use of the backtracking  con‐
+       trol  verbs  (*PRUNE) and (*SKIP) also disable this optimization. To do
+       so explicitly, either pass the compile option  PCRE2_NO_DOTSTAR_ANCHOR,
+       or call pcre2_set_optimize() with a PCRE2_DOTSTAR_ANCHOR_OFF directive.
 
        When  a  capture group is repeated, the value captured is the substring
        that matched the final iteration. For example, after
@@ -8542,10 +8621,12 @@ ATOMIC GROUPING AND POSSESSIVE QUANTIFIERS
        PCRE2 has an optimization  that  automatically  "possessifies"  certain
        simple  pattern constructs. For example, the sequence A+B is treated as
        A++B because there is no point in backtracking into a sequence  of  A's
-       when B must follow.  This feature can be disabled by the PCRE2_NO_AUTO-
-       POSSESS option, or starting the pattern with (*NO_AUTO_POSSESS).
+       when   B   must   follow.    This   feature  can  be  disabled  by  the
+       PCRE2_NO_AUTO_POSSESS option, by calling  pcre2_set_optimize()  with  a
+       PCRE2_AUTO_POSSESS_OFF  directive,  or  by  starting  the  pattern with
+       (*NO_AUTO_POSSESS).
 
-       When a pattern contains an unlimited repeat inside a group that can it-
+       When a pattern contains an unlimited repeat inside a group that can it‐
        self  be  repeated  an  unlimited number of times, the use of an atomic
        group is the only way to avoid some failing matches taking a very  long
        time indeed. The pattern
@@ -9694,10 +9775,11 @@ BACKTRACKING CONTROL
        character must be present. When one of these optimizations bypasses the
        running  of  a  match,  any  included  backtracking  verbs will not, of
        course, be processed. You can suppress the start-of-match optimizations
-       by setting the PCRE2_NO_START_OPTIMIZE option when  calling  pcre2_com-
-       pile(),  or by starting the pattern with (*NO_START_OPT). There is more
-       discussion of this option in the section entitled "Compiling a pattern"
-       in the pcre2api documentation.
+       by  setting  the PCRE2_NO_START_OPTIMIZE option when calling pcre2_com�‐
+       pile(), by calling pcre2_set_optimize() with a  PCRE_START_OPTIMIZE_OFF
+       directive,  or  by starting the pattern with (*NO_START_OPT).  There is
+       more discussion of this option in the  section  entitled  "Compiling  a
+       pattern" in the pcre2api documentation.
 
        Experiments with Perl suggest that it too  has  similar  optimizations,
        and like PCRE2, turning them off can change the result of a match.
@@ -9812,8 +9894,9 @@ BACKTRACKING CONTROL
        as far as the (*MARK) item, but nevertheless do not reset it.
 
        If  you  are  interested  in  (*MARK)  values after failed matches, you
-       should probably set the PCRE2_NO_START_OPTIMIZE option (see  above)  to
-       ensure that the match is always attempted.
+       should probably either set the PCRE2_NO_START_OPTIMIZE option  or  call
+       pcre2_set_optimize()  with  a  PCRE2_START_OPTIMIZE_OFF  directive (see
+       above) to ensure that the match is always attempted.
 
    Verbs that act after backtracking
 

--- a/doc/pcre2_set_optimize.3
+++ b/doc/pcre2_set_optimize.3
@@ -1,0 +1,33 @@
+.TH PCRE2_SET_OPTIMIZE 3 "16 September 2024" "PCRE2 10.45"
+.SH NAME
+PCRE2 - Perl-compatible regular expressions (revised API)
+.SH SYNOPSIS
+.rs
+.sp
+.B #include <pcre2.h>
+.PP
+.nf
+.B int pcre2_set_optimize(pcre2_compile_context *\fIccontext\fP,
+.B "  uint32_t \fIdirective\fP);"
+.fi
+.
+.SH DESCRIPTION
+.rs
+.sp
+This function controls which performance optimizations will be applied
+by \fBpcre2_compile\fP. It can be called multiple times with the same compile
+context; the effects are cumulative, with the effects of later calls taking
+precedence over earlier ones.
+.P
+The result is zero for success, PCRE2_ERROR_NULL if \fIccontext\fP is NULL,
+or PCRE2_ERROR_BADOPTION if \fIdirective\fP is unknown. This can be used to
+detect when the available version of PCRE2 does not implement a certain
+optimization.
+.P
+There is a complete description of the PCRE2 native API, including all
+permitted values for the \fIdirective\fP parameter of \fBpcre2_set_optimize\fP,
+in the
+.\" HREF
+\fBpcre2api\fP
+.\"
+page.

--- a/doc/pcre2api.3
+++ b/doc/pcre2api.3
@@ -115,6 +115,9 @@ document for an overview of all the PCRE2 documentation.
 .sp
 .B int pcre2_set_compile_recursion_guard(pcre2_compile_context *\fIccontext\fP,
 .B "  int (*\fIguard_function\fP)(uint32_t, void *), void *\fIuser_data\fP);"
+.sp
+.B int pcre2_set_optimize(pcre2_compile_context *\fIccontext\fP,
+.B "  uint32_t \fIdirective\fP);"
 .fi
 .
 .
@@ -738,6 +741,7 @@ following compile-time parameters:
   The compile time nested parentheses limit
   The maximum length of the pattern string
   The extra options bits (none set by default)
+  Which performance optimizations the compiler should apply
 .sp
 A compile context is also required if you are using custom memory management.
 If none of these apply, just pass NULL as the context argument of
@@ -881,6 +885,105 @@ The first argument to the callout function gives the current depth of
 nesting, and the second is user data that is set up by the last argument of
 \fBpcre2_set_compile_recursion_guard()\fP. The callout function should return
 zero if all is well, or non-zero to force an error.
+.sp
+.nf
+.B int pcre2_set_optimize(pcre2_compile_context *\fIccontext\fP,
+.B "  uint32_t \fIdirective\fP);"
+.fi
+.sp
+PCRE2 can apply various performance optimizations during compilation, in order
+to make matching faster. For example, the compiler might convert some regex
+constructs into an equivalent construct which \fBpcre2_match()\fP can execute
+faster. By default, all available optimizations are enabled. However, in rare
+cases, one might wish to disable specific optimizations. For example, if it is
+known that some optimizations cannot benefit a certain regex, it might be
+desirable to disable them, in order to speed up compilation.
+.P
+The permitted values of \fIdirective\fP are as follows:
+.sp
+  PCRE2_OPTIMIZATION_NONE
+.sp
+Disable all optional performance optimizations.
+.sp
+  PCRE2_OPTIMIZATION_FULL
+.sp
+Enable all optional performance optimizations. This is the default value.
+.sp
+  PCRE2_AUTO_POSSESS
+  PCRE2_AUTO_POSSESS_OFF
+.sp
+Enable/disable "auto-possessification" of variable quantifiers such as * and +.
+This optimization, for example, turns a+b into a++b in order to avoid
+backtracks into a+ that can never be successful. However, if callouts are in
+use, auto-possessification means that some callouts are never taken. You can
+disable this optimization if you want the matching functions to do a full,
+unoptimized search and run all the callouts.
+.sp
+  PCRE2_DOTSTAR_ANCHOR
+  PCRE2_DOTSTAR_ANCHOR_OFF
+.sp
+Enable/disable an optimization that is applied when .* is the first significant
+item in a top-level branch of a pattern, and all the other branches also start
+with .* or with \eA or \eG or ^. Such a pattern is automatically anchored if
+PCRE2_DOTALL is set for all the .* items and PCRE2_MULTILINE is not set for any
+^ items. Otherwise, the fact that any match must start either at the start of
+the subject or following a newline is remembered. Like other optimizations,
+this can cause callouts to be skipped.
+.P
+Dotstar anchor optimization is automatically disabled for .* if it is inside an
+atomic group or a capture group that is the subject of a backreference, or if
+the pattern contains (*PRUNE) or (*SKIP).
+.sp
+  PCRE2_START_OPTIMIZE
+  PCRE2_START_OPTIMIZE_OFF
+.sp
+Enable/disable optimizations which cause matching functions to scan the subject
+string for specific code unit values before attempting a match. For example, if
+it is known that an unanchored match must start with a specific value, the
+matching code searches the subject for that value, and fails immediately if it
+cannot find it, without actually running the main matching function. This means
+that a special item such as (*COMMIT) at the start of a pattern is not
+considered until after a suitable starting point for the match has been found.
+Also, when callouts or (*MARK) items are in use, these "start-up" optimizations
+can cause them to be skipped if the pattern is never actually used. The start-up
+optimizations are in effect a pre-scan of the subject that takes place before
+the pattern is run.
+.P
+Disabling start-up optimizations ensures that in cases where the result is "no
+match", the callouts do occur, and that items such as (*COMMIT) and (*MARK) are
+considered at every possible starting position in the subject string.
+.P
+Disabling start-up optimizations may change the outcome of a matching operation.
+Consider the pattern
+.sp
+  (*COMMIT)ABC
+.sp
+When this is compiled, PCRE2 records the fact that a match must start with the
+character "A". Suppose the subject string is "DEFABC". The start-up
+optimization scans along the subject, finds "A" and runs the first match
+attempt from there. The (*COMMIT) item means that the pattern must match the
+current starting position, which in this case, it does. However, if the same
+match is run without start-up optimizations, the initial scan along the subject
+string does not happen. The first match attempt is run starting from "D" and
+when this fails, (*COMMIT) prevents any further matches being tried, so the
+overall result is "no match".
+.P
+Another start-up optimization makes use of a minimum length for a matching
+subject, which is recorded when possible. Consider the pattern
+.sp
+  (*MARK:1)B(*MARK:2)(X|Y)
+.sp
+The minimum length for a match is two characters. If the subject is "XXBB", the
+"starting character" optimization skips "XX", then tries to match "BB", which
+is long enough. In the process, (*MARK:2) is encountered and remembered. When
+the match attempt fails, the next "B" is found, but there is only one character
+left, so there are no more attempts, and "no match" is returned with the "last
+mark seen" set to "2". Without start-up optimizations, however, matches are
+tried at every possible starting position, including at the end of the subject,
+where (*MARK:1) is encountered, but there is no "B", so the "last mark seen"
+that is returned is "1". In this case, the optimizations do not affect the
+overall match result, which is still "no match", but they do affect the
+auxiliary information that is returned.
 .
 .
 .\" HTML <a name="matchcontext"></a>
@@ -1748,81 +1851,54 @@ though the reference can be by name or by number.
 .sp
   PCRE2_NO_AUTO_POSSESS
 .sp
-If this option is set, it disables "auto-possessification", which is an
-optimization that, for example, turns a+b into a++b in order to avoid
+If this (deprecated) option is set, it disables "auto-possessification", which
+is an optimization that, for example, turns a+b into a++b in order to avoid
 backtracks into a+ that can never be successful. However, if callouts are in
 use, auto-possessification means that some callouts are never taken. You can
 set this option if you want the matching functions to do a full unoptimized
 search and run all the callouts, but it is mainly provided for testing
 purposes.
+.P
+If a compile context is available, it is recommended to use
+\fBpcre2_set_optimize()\fP with the \fIdirective\fP PCRE2_AUTO_POSSESS_OFF rather
+than the compile option PCRE2_NO_AUTO_POSSESS. Note that PCRE2_NO_AUTO_POSSESS
+takes precedence over the \fBpcre2_set_optimize()\fP optimization directives
+PCRE2_AUTO_POSSESS and PCRE2_AUTO_POSSESS_OFF.
 .sp
   PCRE2_NO_DOTSTAR_ANCHOR
 .sp
-If this option is set, it disables an optimization that is applied when .* is
-the first significant item in a top-level branch of a pattern, and all the
-other branches also start with .* or with \eA or \eG or ^. The optimization is
-automatically disabled for .* if it is inside an atomic group or a capture
-group that is the subject of a backreference, or if the pattern contains
-(*PRUNE) or (*SKIP). When the optimization is not disabled, such a pattern is
-automatically anchored if PCRE2_DOTALL is set for all the .* items and
-PCRE2_MULTILINE is not set for any ^ items. Otherwise, the fact that any match
-must start either at the start of the subject or following a newline is
+If this (deprecated) option is set, it disables an optimization that is applied
+when .* is the first significant item in a top-level branch of a pattern, and
+all the other branches also start with .* or with \eA or \eG or ^. The
+optimization is automatically disabled for .* if it is inside an atomic group
+or a capture group that is the subject of a backreference, or if the pattern
+contains (*PRUNE) or (*SKIP). When the optimization is not disabled, such a
+pattern is automatically anchored if PCRE2_DOTALL is set for all the .* items
+and PCRE2_MULTILINE is not set for any ^ items. Otherwise, the fact that any
+match must start either at the start of the subject or following a newline is
 remembered. Like other optimizations, this can cause callouts to be skipped.
+(If a compile context is available, it is recommended to use
+\fBpcre2_set_optimize()\fP with the \fIdirective\fP PCRE2_DOTSTAR_ANCHOR_OFF
+instead.)
 .sp
   PCRE2_NO_START_OPTIMIZE
 .sp
 This is an option whose main effect is at matching time. It does not change
 what \fBpcre2_compile()\fP generates, but it does affect the output of the JIT
-compiler.
+compiler. Setting this option is equivalent to calling \fBpcre2_set_optimize()\fP
+with the \fIdirective\fP parameter set to PCRE2_START_OPTIMIZE_OFF.
 .P
 There are a number of optimizations that may occur at the start of a match, in
 order to speed up the process. For example, if it is known that an unanchored
 match must start with a specific code unit value, the matching code searches
 the subject for that value, and fails immediately if it cannot find it, without
-actually running the main matching function. This means that a special item
-such as (*COMMIT) at the start of a pattern is not considered until after a
-suitable starting point for the match has been found. Also, when callouts or
-(*MARK) items are in use, these "start-up" optimizations can cause them to be
-skipped if the pattern is never actually used. The start-up optimizations are
+actually running the main matching function. The start-up optimizations are
 in effect a pre-scan of the subject that takes place before the pattern is run.
 .P
-The PCRE2_NO_START_OPTIMIZE option disables the start-up optimizations,
-possibly causing performance to suffer, but ensuring that in cases where the
-result is "no match", the callouts do occur, and that items such as (*COMMIT)
-and (*MARK) are considered at every possible starting position in the subject
-string.
-.P
-Setting PCRE2_NO_START_OPTIMIZE may change the outcome of a matching operation.
-Consider the pattern
-.sp
-  (*COMMIT)ABC
-.sp
-When this is compiled, PCRE2 records the fact that a match must start with the
-character "A". Suppose the subject string is "DEFABC". The start-up
-optimization scans along the subject, finds "A" and runs the first match
-attempt from there. The (*COMMIT) item means that the pattern must match the
-current starting position, which in this case, it does. However, if the same
-match is run with PCRE2_NO_START_OPTIMIZE set, the initial scan along the
-subject string does not happen. The first match attempt is run starting from
-"D" and when this fails, (*COMMIT) prevents any further matches being tried, so
-the overall result is "no match".
-.P
-As another start-up optimization makes use of a minimum length for a matching
-subject, which is recorded when possible. Consider the pattern
-.sp
-  (*MARK:1)B(*MARK:2)(X|Y)
-.sp
-The minimum length for a match is two characters. If the subject is "XXBB", the
-"starting character" optimization skips "XX", then tries to match "BB", which
-is long enough. In the process, (*MARK:2) is encountered and remembered. When
-the match attempt fails, the next "B" is found, but there is only one character
-left, so there are no more attempts, and "no match" is returned with the "last
-mark seen" set to "2". If NO_START_OPTIMIZE is set, however, matches are tried
-at every possible starting position, including at the end of the subject, where
-(*MARK:1) is encountered, but there is no "B", so the "last mark seen" that is
-returned is "1". In this case, the optimizations do not affect the overall
-match result, which is still "no match", but they do affect the auxiliary
-information that is returned.
+Disabling the start-up optimizations may cause performance to suffer. However,
+this may be desirable for patterns which contain callouts or items such as
+(*COMMIT) and (*MARK). See the above description of PCRE2_START_OPTIMIZE_OFF
+for further details.
 .sp
   PCRE2_NO_UTF_CHECK
 .sp
@@ -2272,6 +2348,7 @@ following are true:
   PCRE2_DOTALL is in force for .*
   Neither (*PRUNE) nor (*SKIP) appears in the pattern
   PCRE2_NO_DOTSTAR_ANCHOR is not set
+  Dotstar anchoring has not been disabled with PCRE2_DOTSTAR_ANCHOR_OFF
 .sp
 For patterns that are auto-anchored, the PCRE2_ANCHORED bit is set in the
 options returned for PCRE2_INFO_ALLOPTIONS.

--- a/doc/pcre2api.3
+++ b/doc/pcre2api.3
@@ -1768,6 +1768,11 @@ PCRE2_NO_START_OPTIMIZE, PCRE2_NO_UTF_CHECK, PCRE2_UTF, and
 PCRE2_USE_OFFSET_LIMIT. The extra options PCRE2_EXTRA_MATCH_LINE and
 PCRE2_EXTRA_MATCH_WORD are also supported. Any other options cause an error.
 .sp
+Starting with 10.45, PCRE2_NO_AUTO_POSSESS and PCRE2_NO_DOTSTAR_ANCHOR are
+considered deprecated and therefore their corresponding optimizations could be
+disabled instead by calling \fBpcre2_set_optimize()\fP, in that case no error
+should be expected from \fBpcre2_compile()\fP.
+.sp
   PCRE2_MATCH_INVALID_UTF
 .sp
 This option forces PCRE2_UTF (see below) and also enables support for matching

--- a/doc/pcre2pattern.3
+++ b/doc/pcre2pattern.3
@@ -104,7 +104,8 @@ of the subject.
 .rs
 .sp
 If a pattern starts with (*NO_AUTO_POSSESS), it has the same effect as setting
-the PCRE2_NO_AUTO_POSSESS option. This stops PCRE2 from making quantifiers
+the PCRE2_NO_AUTO_POSSESS option, or calling \fBpcre2_set_optimize()\fP with
+a PCRE2_AUTO_POSSESS_OFF directive. This stops PCRE2 from making quantifiers
 possessive when what follows cannot match the repeated item. For example, by
 default a+b is treated as a++b. For more details, see the
 .\" HREF
@@ -117,8 +118,9 @@ documentation.
 .rs
 .sp
 If a pattern starts with (*NO_START_OPT), it has the same effect as setting the
-PCRE2_NO_START_OPTIMIZE option. This disables several optimizations for quickly
-reaching "no match" results. For more details, see the
+PCRE2_NO_START_OPTIMIZE option, or calling \fBpcre2_set_optimize()\fP with
+a PCRE2_START_OPTIMIZE_OFF directive. This disables several optimizations for
+quickly reaching "no match" results. For more details, see the
 .\" HREF
 \fBpcre2api\fP
 .\"
@@ -129,7 +131,8 @@ documentation.
 .rs
 .sp
 If a pattern starts with (*NO_DOTSTAR_ANCHOR), it has the same effect as
-setting the PCRE2_NO_DOTSTAR_ANCHOR option. This disables optimizations that
+setting the PCRE2_NO_DOTSTAR_ANCHOR option, or calling \fBpcre2_set_optimize()\fP
+with a PCRE2_DOTSTAR_ANCHOR_OFF directive. This disables optimizations that
 apply to patterns whose top-level branches all start with .* (match any number
 of arbitrary characters). For more details, see the
 .\" HREF
@@ -2149,8 +2152,9 @@ one succeeds. Consider this pattern:
   (?>.*?a)b
 .sp
 It matches "ab" in the subject "aab". The use of the backtracking control verbs
-(*PRUNE) and (*SKIP) also disable this optimization, and there is an option,
-PCRE2_NO_DOTSTAR_ANCHOR, to do so explicitly.
+(*PRUNE) and (*SKIP) also disable this optimization. To do so explicitly,
+either pass the compile option PCRE2_NO_DOTSTAR_ANCHOR, or call
+\fBpcre2_set_optimize()\fP with a PCRE2_DOTSTAR_ANCHOR_OFF directive.
 .P
 When a capture group is repeated, the value captured is the substring that
 matched the final iteration. For example, after
@@ -2242,8 +2246,9 @@ package, and PCRE1 copied it from there. It found its way into Perl at release
 PCRE2 has an optimization that automatically "possessifies" certain simple
 pattern constructs. For example, the sequence A+B is treated as A++B because
 there is no point in backtracking into a sequence of A's when B must follow.
-This feature can be disabled by the PCRE2_NO_AUTOPOSSESS option, or starting
-the pattern with (*NO_AUTO_POSSESS).
+This feature can be disabled by the PCRE2_NO_AUTO_POSSESS option, by calling
+\fBpcre2_set_optimize()\fP with a PCRE2_AUTO_POSSESS_OFF directive, or by
+starting the pattern with (*NO_AUTO_POSSESS).
 .P
 When a pattern contains an unlimited repeat inside a group that can itself be
 repeated an unlimited number of times, the use of an atomic group is the only
@@ -3514,9 +3519,9 @@ minimum length of matching subject, or that a particular character must be
 present. When one of these optimizations bypasses the running of a match, any
 included backtracking verbs will not, of course, be processed. You can suppress
 the start-of-match optimizations by setting the PCRE2_NO_START_OPTIMIZE option
-when calling \fBpcre2_compile()\fP, or by starting the pattern with
-(*NO_START_OPT). There is more discussion of this option in the section
-entitled
+when calling \fBpcre2_compile()\fP, by calling \fBpcre2_set_optimize()\fP with a
+PCRE_START_OPTIMIZE_OFF directive, or by starting the pattern with (*NO_START_OPT).
+There is more discussion of this option in the section entitled
 .\" HTML <a href="pcre2api.html#compiling">
 .\" </a>
 "Compiling a pattern"
@@ -3648,7 +3653,8 @@ attempts starting at "P" and then with an empty string do not get as far as the
 (*MARK) item, but nevertheless do not reset it.
 .P
 If you are interested in (*MARK) values after failed matches, you should
-probably set the PCRE2_NO_START_OPTIMIZE option
+probably either set the PCRE2_NO_START_OPTIMIZE option or call
+\fBpcre2_set_optimize()\fP with a PCRE2_START_OPTIMIZE_OFF directive
 .\" HTML <a href="#nooptimize">
 .\" </a>
 (see above)

--- a/doc/pcre2test.1
+++ b/doc/pcre2test.1
@@ -636,6 +636,24 @@ notation. Otherwise, those less than 0x100 are output in hex without the curly
 brackets. Setting \fButf\fP in 16-bit or 32-bit mode also causes pattern and
 subject strings to be translated to UTF-16 or UTF-32, respectively, before
 being passed to library functions.
+.sp
+The following modifiers enable or disable performance optimizations by
+calling \fBpcre2_set_optimize()\fP before invoking the regex compiler.
+.sp
+      optimization_full      enable all optional optimizations
+      optimization_none      disable all optional optimizations
+      auto_possess           auto-possessify variable quantifiers
+      auto_possess_off       don't auto-possessify variable quantifiers
+      dotstar_anchor         anchor patterns starting with .*
+      dotstar_anchor_off     don't anchor patterns starting with .*
+      start_optimize         enable pre-scan of subject string
+      start_optimize_off     disable pre-scan of subject string
+.sp
+See the
+.\" HREF
+\fBpcre2_set_optimize\fP
+.\"
+documentation for details on these optimizations.
 .
 .
 .\" HTML <a name="controlmodifiers"></a>

--- a/doc/pcre2test.txt
+++ b/doc/pcre2test.txt
@@ -618,6 +618,21 @@ PATTERN MODIFIERS
        causes  pattern  and  subject  strings  to  be  translated to UTF-16 or
        UTF-32, respectively, before being passed to library functions.
 
+       The following modifiers enable or disable performance optimizations  by
+       calling pcre2_set_optimize() before invoking the regex compiler.
+
+             optimization_full      enable all optional optimizations
+             optimization_none      disable all optional optimizations
+             auto_possess           auto-possessify variable quantifiers
+             auto_possess_off       don't auto-possessify variable quantifiers
+             dotstar_anchor         anchor patterns starting with .*
+             dotstar_anchor_off     don't anchor patterns starting with .*
+             start_optimize         enable pre-scan of subject string
+             start_optimize_off     disable pre-scan of subject string
+
+       See the pcre2_set_optimize documentation for details on these optimiza‐
+       tions.
+
    Setting compilation controls
 
        The following modifiers affect the compilation process or  request  in-

--- a/src/pcre2.h.generic
+++ b/src/pcre2.h.generic
@@ -464,6 +464,18 @@ released, the numbers must not be changed. */
 #define PCRE2_CONFIG_COMPILED_WIDTHS        14
 #define PCRE2_CONFIG_TABLES_LENGTH          15
 
+/* Optimization directives for pcre2_set_optimize().
+For binary compatibility, only add to this list; do not renumber. */
+
+#define PCRE2_OPTIMIZATION_NONE    0
+#define PCRE2_OPTIMIZATION_FULL    1
+
+#define PCRE2_AUTO_POSSESS         64
+#define PCRE2_AUTO_POSSESS_OFF     65
+#define PCRE2_DOTSTAR_ANCHOR       66
+#define PCRE2_DOTSTAR_ANCHOR_OFF   67
+#define PCRE2_START_OPTIMIZE       68
+#define PCRE2_START_OPTIMIZE_OFF   69
 
 /* Types for code units in patterns and subject strings. */
 
@@ -617,7 +629,9 @@ PCRE2_EXP_DECL int PCRE2_CALL_CONVENTION \
   pcre2_set_parens_nest_limit(pcre2_compile_context *, uint32_t); \
 PCRE2_EXP_DECL int PCRE2_CALL_CONVENTION \
   pcre2_set_compile_recursion_guard(pcre2_compile_context *, \
-    int (*)(uint32_t, void *), void *);
+    int (*)(uint32_t, void *), void *); \
+PCRE2_EXP_DECL int PCRE2_CALL_CONVENTION \
+  pcre2_set_optimize(pcre2_compile_context *, uint32_t);
 
 #define PCRE2_MATCH_CONTEXT_FUNCTIONS \
 PCRE2_EXP_DECL pcre2_match_context *PCRE2_CALL_CONVENTION \
@@ -912,6 +926,7 @@ pcre2_compile are called by application code. */
 #define pcre2_set_newline                     PCRE2_SUFFIX(pcre2_set_newline_)
 #define pcre2_set_parens_nest_limit           PCRE2_SUFFIX(pcre2_set_parens_nest_limit_)
 #define pcre2_set_offset_limit                PCRE2_SUFFIX(pcre2_set_offset_limit_)
+#define pcre2_set_optimize                    PCRE2_SUFFIX(pcre2_set_optimize_)
 #define pcre2_set_substitute_callout          PCRE2_SUFFIX(pcre2_set_substitute_callout_)
 #define pcre2_substitute                      PCRE2_SUFFIX(pcre2_substitute_)
 #define pcre2_substring_copy_byname           PCRE2_SUFFIX(pcre2_substring_copy_byname_)

--- a/src/pcre2.h.in
+++ b/src/pcre2.h.in
@@ -464,6 +464,18 @@ released, the numbers must not be changed. */
 #define PCRE2_CONFIG_COMPILED_WIDTHS        14
 #define PCRE2_CONFIG_TABLES_LENGTH          15
 
+/* Optimization directives for pcre2_set_optimize().
+For binary compatibility, only add to this list; do not renumber. */
+
+#define PCRE2_OPTIMIZATION_NONE    0
+#define PCRE2_OPTIMIZATION_FULL    1
+
+#define PCRE2_AUTO_POSSESS         64
+#define PCRE2_AUTO_POSSESS_OFF     65
+#define PCRE2_DOTSTAR_ANCHOR       66
+#define PCRE2_DOTSTAR_ANCHOR_OFF   67
+#define PCRE2_START_OPTIMIZE       68
+#define PCRE2_START_OPTIMIZE_OFF   69
 
 /* Types for code units in patterns and subject strings. */
 
@@ -617,7 +629,9 @@ PCRE2_EXP_DECL int PCRE2_CALL_CONVENTION \
   pcre2_set_parens_nest_limit(pcre2_compile_context *, uint32_t); \
 PCRE2_EXP_DECL int PCRE2_CALL_CONVENTION \
   pcre2_set_compile_recursion_guard(pcre2_compile_context *, \
-    int (*)(uint32_t, void *), void *);
+    int (*)(uint32_t, void *), void *); \
+PCRE2_EXP_DECL int PCRE2_CALL_CONVENTION \
+  pcre2_set_optimize(pcre2_compile_context *, uint32_t);
 
 #define PCRE2_MATCH_CONTEXT_FUNCTIONS \
 PCRE2_EXP_DECL pcre2_match_context *PCRE2_CALL_CONVENTION \
@@ -912,6 +926,7 @@ pcre2_compile are called by application code. */
 #define pcre2_set_newline                     PCRE2_SUFFIX(pcre2_set_newline_)
 #define pcre2_set_parens_nest_limit           PCRE2_SUFFIX(pcre2_set_parens_nest_limit_)
 #define pcre2_set_offset_limit                PCRE2_SUFFIX(pcre2_set_offset_limit_)
+#define pcre2_set_optimize                    PCRE2_SUFFIX(pcre2_set_optimize_)
 #define pcre2_set_substitute_callout          PCRE2_SUFFIX(pcre2_set_substitute_callout_)
 #define pcre2_substitute                      PCRE2_SUFFIX(pcre2_substitute_)
 #define pcre2_substring_copy_byname           PCRE2_SUFFIX(pcre2_substring_copy_byname_)

--- a/src/pcre2_compile.c
+++ b/src/pcre2_compile.c
@@ -10419,12 +10419,20 @@ if ((options & ~PUBLIC_COMPILE_OPTIONS) != 0 ||
   return NULL;
   }
 
-if ((options & PCRE2_LITERAL) != 0 &&
-    ((options & ~PUBLIC_LITERAL_COMPILE_OPTIONS) != 0 ||
-     (ccontext->extra_options & ~PUBLIC_LITERAL_COMPILE_EXTRA_OPTIONS) != 0))
+if ((options & PCRE2_LITERAL) != 0)
   {
-  *errorptr = ERR92;
-  return NULL;
+    if ((options & ~PUBLIC_LITERAL_COMPILE_OPTIONS) != 0 ||
+        (ccontext->extra_options & ~PUBLIC_LITERAL_COMPILE_EXTRA_OPTIONS) != 0)
+    {
+    *errorptr = ERR92;
+    return NULL;
+    }
+
+/* The auto_possessification and dotstar_anchor optimizations can also be
+disabled by calling pcre2_set_optimize() so make sure to ignore those bits
+for consisency. */
+
+    optim_flags |= (PCRE2_OPTIM_AUTO_POSSESS | PCRE2_OPTIM_DOTSTAR_ANCHOR);
   }
 
 /* A zero-terminated pattern is indicated by the special length value

--- a/src/pcre2_context.c
+++ b/src/pcre2_context.c
@@ -141,7 +141,8 @@ pcre2_compile_context PRIV(default_compile_context) = {
   NEWLINE_DEFAULT,                           /* Newline convention */
   PARENS_NEST_LIMIT,                         /* As it says */
   0,                                         /* Extra options */
-  MAX_VARLOOKBEHIND                          /* As it says */
+  MAX_VARLOOKBEHIND,                         /* As it says */
+  PCRE2_OPTIMIZATION_ALL                     /* All optimizations enabled */
   };
 
 /* The create function copies the default into the new memory, but must
@@ -409,6 +410,38 @@ ccontext->stack_guard_data = user_data;
 return 0;
 }
 
+PCRE2_EXP_DEFN int PCRE2_CALL_CONVENTION
+pcre2_set_optimize(pcre2_compile_context *ccontext, uint32_t directive)
+{
+if (ccontext == NULL)
+  return PCRE2_ERROR_NULL;
+
+switch (directive)
+  {
+  case PCRE2_OPTIMIZATION_NONE:
+  ccontext->optimization_flags = 0;
+  break;
+
+  case PCRE2_OPTIMIZATION_FULL:
+  ccontext->optimization_flags = PCRE2_OPTIMIZATION_ALL;
+  break;
+
+  default:
+  if (directive >= PCRE2_AUTO_POSSESS && directive <= PCRE2_START_OPTIMIZE_OFF)
+    {
+    /* Even directive numbers starting from 64 switch a bit on;
+     * Odd directive numbers starting from 65 switch a bit off */
+    if ((directive & 1) != 0)
+      ccontext->optimization_flags &= ~(1u << ((directive >> 1) - 32));
+    else
+      ccontext->optimization_flags |= 1u << ((directive >> 1) - 32);
+    return 0;
+    }
+  return PCRE2_ERROR_BADOPTION;
+  }
+
+return 0;
+}
 
 /* ------------ Match context ------------ */
 

--- a/src/pcre2_dfa_match.c
+++ b/src/pcre2_dfa_match.c
@@ -3432,7 +3432,7 @@ if ((re->flags & PCRE2_MODE_MASK) != PCRE2_CODE_UNIT_WIDTH/8)
 /* PCRE2_NOTEMPTY and PCRE2_NOTEMPTY_ATSTART are match-time flags in the
 options variable for this function. Users of PCRE2 who are not calling the
 function directly would like to have a way of setting these flags, in the same
-way that they can set pcre2_compile() flags like PCRE2_NO_AUTOPOSSESS with
+way that they can set pcre2_compile() flags like PCRE2_NO_AUTO_POSSESS with
 constructions like (*NO_AUTOPOSSESS). To enable this, (*NOTEMPTY) and
 (*NOTEMPTY_ATSTART) set bits in the pattern's "flag" function which can now be
 transferred to the options for this function. The bits are guaranteed to be
@@ -3699,7 +3699,7 @@ for (;;)
   these, for testing and for ensuring that all callouts do actually occur.
   The optimizations must also be avoided when restarting a DFA match. */
 
-  if ((re->overall_options & PCRE2_NO_START_OPTIMIZE) == 0 &&
+  if ((re->optimization_flags & PCRE2_OPTIM_START_OPTIMIZE) != 0 &&
       (options & PCRE2_DFA_RESTART) == 0)
     {
     /* If firstline is TRUE, the start of the match is constrained to the first

--- a/src/pcre2_internal.h
+++ b/src/pcre2_internal.h
@@ -609,6 +609,13 @@ total length of the tables. */
 #define ctypes_offset (cbits_offset + cbit_length)  /* Character types */
 #define TABLES_LENGTH (ctypes_offset + 256)
 
+/* Private flags used in compile_context.optimization_flags */
+
+#define PCRE2_OPTIM_AUTO_POSSESS    0x00000001u
+#define PCRE2_OPTIM_DOTSTAR_ANCHOR  0x00000002u
+#define PCRE2_OPTIM_START_OPTIMIZE  0x00000004u
+
+#define PCRE2_OPTIMIZATION_ALL      0x00000007u
 
 /* -------------------- Character and string names ------------------------ */
 

--- a/src/pcre2_intmodedep.h
+++ b/src/pcre2_intmodedep.h
@@ -579,6 +579,7 @@ typedef struct pcre2_real_compile_context {
   uint32_t parens_nest_limit;
   uint32_t extra_options;
   uint32_t max_varlookbehind;
+  uint32_t optimization_flags;
 } pcre2_real_compile_context;
 
 /* The real match context structure. */
@@ -646,6 +647,7 @@ typedef struct pcre2_real_code {
   uint16_t top_backref;           /* Highest numbered back reference */
   uint16_t name_entry_size;       /* Size (code units) of table entries */
   uint16_t name_count;            /* Number of name entries in the table */
+  uint32_t optimization_flags;    /* Optimizations enabled at compile time */
 } pcre2_real_code;
 
 /* The real match data structure. Define ovector as large as it can ever

--- a/src/pcre2_jit_compile.c
+++ b/src/pcre2_jit_compile.c
@@ -14474,7 +14474,9 @@ if (!check_opcode_types(common, common->start, ccend))
   }
 
 /* Checking flags and updating ovector_start. */
-if (mode == PCRE2_JIT_COMPLETE && (re->flags & PCRE2_LASTSET) != 0 && (re->overall_options & PCRE2_NO_START_OPTIMIZE) == 0)
+if (mode == PCRE2_JIT_COMPLETE &&
+    (re->flags & PCRE2_LASTSET) != 0 &&
+    (re->optimization_flags & PCRE2_OPTIM_START_OPTIMIZE) != 0)
   {
   common->req_char_ptr = common->ovector_start;
   common->ovector_start += sizeof(sljit_sw);
@@ -14534,7 +14536,9 @@ memset(common->private_data_ptrs, 0, total_length * sizeof(sljit_s32));
 
 private_data_size = common->cbra_ptr + (re->top_bracket + 1) * sizeof(sljit_sw);
 
-if ((re->overall_options & PCRE2_ANCHORED) == 0 && (re->overall_options & PCRE2_NO_START_OPTIMIZE) == 0 && !common->has_skip_in_assert_back)
+if ((re->overall_options & PCRE2_ANCHORED) == 0 &&
+    (re->optimization_flags & PCRE2_OPTIM_START_OPTIMIZE) != 0 &&
+    !common->has_skip_in_assert_back)
   detect_early_fail(common, common->start, &private_data_size, 0, 0);
 
 set_private_data_ptrs(common, &private_data_size, ccend);
@@ -14600,7 +14604,7 @@ if ((re->overall_options & PCRE2_ANCHORED) == 0)
   mainloop_label = mainloop_entry(common);
   continue_match_label = LABEL();
   /* Forward search if possible. */
-  if ((re->overall_options & PCRE2_NO_START_OPTIMIZE) == 0)
+  if ((re->optimization_flags & PCRE2_OPTIM_START_OPTIMIZE) != 0)
     {
     if (mode == PCRE2_JIT_COMPLETE && fast_forward_first_n_chars(common))
       ;
@@ -14615,7 +14619,8 @@ if ((re->overall_options & PCRE2_ANCHORED) == 0)
 else
   continue_match_label = LABEL();
 
-if (mode == PCRE2_JIT_COMPLETE && re->minlength > 0 && (re->overall_options & PCRE2_NO_START_OPTIMIZE) == 0)
+if (mode == PCRE2_JIT_COMPLETE && re->minlength > 0 &&
+    (re->optimization_flags & PCRE2_OPTIM_START_OPTIMIZE) != 0)
   {
   OP1(SLJIT_MOV, SLJIT_RETURN_REG, 0, SLJIT_IMM, PCRE2_ERROR_NOMATCH);
   OP2(SLJIT_ADD, TMP2, 0, STR_PTR, 0, SLJIT_IMM, IN_UCHARS(re->minlength));

--- a/src/pcre2_match.c
+++ b/src/pcre2_match.c
@@ -6788,7 +6788,7 @@ if ((re->flags & PCRE2_MODE_MASK) != PCRE2_CODE_UNIT_WIDTH/8)
 /* PCRE2_NOTEMPTY and PCRE2_NOTEMPTY_ATSTART are match-time flags in the
 options variable for this function. Users of PCRE2 who are not calling the
 function directly would like to have a way of setting these flags, in the same
-way that they can set pcre2_compile() flags like PCRE2_NO_AUTOPOSSESS with
+way that they can set pcre2_compile() flags like PCRE2_NO_AUTO_POSSESS with
 constructions like (*NO_AUTOPOSSESS). To enable this, (*NOTEMPTY) and
 (*NOTEMPTY_ATSTART) set bits in the pattern's "flag" function which we now
 transfer to the options for this function. The bits are guaranteed to be
@@ -7326,7 +7326,7 @@ for(;;)
   However, there is an option (settable at compile time) that disables these,
   for testing and for ensuring that all callouts do actually occur. */
 
-  if ((re->overall_options & PCRE2_NO_START_OPTIMIZE) == 0)
+  if ((re->optimization_flags & PCRE2_OPTIM_START_OPTIMIZE) != 0)
     {
     /* If firstline is TRUE, the start of the match is constrained to the first
     line of a multiline string. That is, the match must be before or at the

--- a/testdata/testinput2
+++ b/testdata/testinput2
@@ -5456,17 +5456,17 @@ a)"xI
     syndicate
 
 # Confirm that the pcre2_set_optimize API does not have any undesired effect on literal patterns
-/(cat)|dog/literal,auto_possess_off
+/(cat)|dog/I,literal,auto_possess_off
     (cat)|dog
 \= Expect no match
     the cat sat
 
-/(cat)|dog/literal,dotstar_anchor_off
+/(cat)|dog/I,literal,dotstar_anchor_off
     (cat)|dog
 \= Expect no match
     the cat sat
 
-/(cat)|dog/literal,optimization_none
+/(cat)|dog/I,literal,optimization_none
     (cat)|dog
 \= Expect no match
     the cat sat

--- a/testdata/testinput2
+++ b/testdata/testinput2
@@ -831,6 +831,19 @@
 
 /x++/IB
 
+# For comparison with the following test, which disables auto-possessification
+# In this regex, x+ should be converted to x++
+/x+y/B,auto_possess
+
+# In this regex, x+ should not be converted to x++
+/x+y/B,auto_possess_off
+
+# Also in this regex, x+ should not be converted to x++
+/x+y/B,optimization_none
+
+# In this one too, x+ should not be converted to x++
+/x+y/B,no_auto_possess
+
 /x{1,3}+/B,no_auto_possess
 
 /x{1,3}+/Bi,no_auto_possess
@@ -838,6 +851,8 @@
 /[^x]{1,3}+/B,no_auto_possess
 
 /[^x]{1,3}+/Bi,no_auto_possess
+
+/x{1,3}+/IB,auto_possess_off
 
 /(x)*+/IB
 
@@ -4056,9 +4071,15 @@
 
 /(?(VERSION=10.101)yes|no)/
 
+# We should see the starting code unit, required code unit, and minimum length set for this regex:
 /abcd/I
 
+# None of the following three should have the starting code unit, required code unit, and minimum length set:
 /abcd/I,no_start_optimize
+
+/abcd/I,start_optimize_off
+
+/abcd/I,optimization_none
 
 /(|ab)*?d/I
    abd
@@ -4223,6 +4244,19 @@
 /^abc/info
 
 /^abc/info,no_dotstar_anchor
+
+/^abc/info,dotstar_anchor_off
+
+# For comparison with the following tests, which disable automatic dotstar anchoring
+/.*abc/BI
+
+/.*abc/BI,dotstar_anchor_off
+
+/.*abc/BI,start_optimize_off
+
+/.*abc/BI,optimization_none
+
+/.*abc/BI,no_dotstar_anchor
 
 /.*\d/info,auto_callout
 \= Expect no match
@@ -5421,6 +5455,28 @@ a)"xI
     snowcat
     syndicate
 
+# Confirm that the pcre2_set_optimize API does not have any undesired effect on literal patterns
+/(cat)|dog/literal,auto_possess_off
+    (cat)|dog
+\= Expect no match
+    the cat sat
+
+/(cat)|dog/literal,dotstar_anchor_off
+    (cat)|dog
+\= Expect no match
+    the cat sat
+
+/(cat)|dog/literal,optimization_none
+    (cat)|dog
+\= Expect no match
+    the cat sat
+
+# These should result in errors, since it is not permitted to use the
+# PCRE2_NO_AUTO_POSSESS and PCRE2_NO_DOTSTAR_ANCHOR options on a literal pattern
+/(cat)|dog/literal,no_auto_possess
+
+/(cat)|dog/literal,no_dotstar_anchor
+
 /a whole line/match_line,multiline
     Rhubarb \na whole line\n custard
 \= Expect no match
@@ -6389,6 +6445,27 @@ a)"xI
 /(?<AA>a)(*scan_substring:(1,'AA',1,<AA>)a)b/B
     ab
     ac
+
+# Tests for pcre2_set_optimize()
+
+/abc/I,optimization_none
+
+/abc/I,optimization_none,auto_possess
+
+/abc/I,optimization_none,dotstar_anchor,auto_possess
+
+/abc/I,optimization_none,start_optimize
+
+/abc/I,dotstar_anchor_off,optimization_full
+
+# If pcre2_set_optimize() is used to turn on some optimization, but at the same time,
+# the compile options word turns it off... the compile options word "wins":
+
+/abc/I,no_auto_possess,auto_possess
+
+/abc/I,no_dotstar_anchor,dotstar_anchor
+
+/abc/I,no_start_optimize,start_optimize
 
 # --------------
 

--- a/testdata/testoutput15
+++ b/testdata/testoutput15
@@ -477,6 +477,7 @@ Failed: error -52: nested recursion at the same subject position
 ------------------------------------------------------------------
 Capture group count = 0
 Options: no_auto_possess
+Optimizations: dotstar_anchor,start_optimize
 Starting code units: 0 1 2 3 4 5 6 7 8 9 A B C D E F G H I J K L M N O P
   Q R S T U V W X Y Z _ a b c d e f g h i j k l m n o p q r s t u v w x y z
 Subject length lower bound = 1
@@ -501,6 +502,7 @@ No match
 Capture group count = 0
 Compile options: <none>
 Overall options: no_auto_possess
+Optimizations: dotstar_anchor,start_optimize
 Starting code units: 0 1 2 3 4 5 6 7 8 9 A B C D E F G H I J K L M N O P
   Q R S T U V W X Y Z _ a b c d e f g h i j k l m n o p q r s t u v w x y z
 Subject length lower bound = 1

--- a/testdata/testoutput2
+++ b/testdata/testoutput2
@@ -2942,6 +2942,47 @@ Capture group count = 0
 First code unit = 'x'
 Subject length lower bound = 1
 
+# For comparison with the following test, which disables auto-possessification
+# In this regex, x+ should be converted to x++
+/x+y/B,auto_possess
+------------------------------------------------------------------
+        Bra
+        x++
+        y
+        Ket
+        End
+------------------------------------------------------------------
+
+# In this regex, x+ should not be converted to x++
+/x+y/B,auto_possess_off
+------------------------------------------------------------------
+        Bra
+        x+
+        y
+        Ket
+        End
+------------------------------------------------------------------
+
+# Also in this regex, x+ should not be converted to x++
+/x+y/B,optimization_none
+------------------------------------------------------------------
+        Bra
+        x+
+        y
+        Ket
+        End
+------------------------------------------------------------------
+
+# In this one too, x+ should not be converted to x++
+/x+y/B,no_auto_possess
+------------------------------------------------------------------
+        Bra
+        x+
+        y
+        Ket
+        End
+------------------------------------------------------------------
+
 /x{1,3}+/B,no_auto_possess
 ------------------------------------------------------------------
         Bra
@@ -2977,6 +3018,19 @@ Subject length lower bound = 1
         Ket
         End
 ------------------------------------------------------------------
+
+/x{1,3}+/IB,auto_possess_off
+------------------------------------------------------------------
+        Bra
+        x
+        x{0,2}+
+        Ket
+        End
+------------------------------------------------------------------
+Capture group count = 0
+Optimizations: dotstar_anchor,start_optimize
+First code unit = 'x'
+Subject length lower bound = 1
 
 /(x)*+/IB
 ------------------------------------------------------------------
@@ -13592,15 +13646,26 @@ Failed: error 179 at offset 16: syntax error or number too big in (?(VERSION con
 /(?(VERSION=10.101)yes|no)/
 Failed: error 179 at offset 16: syntax error or number too big in (?(VERSION condition
 
+# We should see the starting code unit, required code unit, and minimum length set for this regex:
 /abcd/I
 Capture group count = 0
 First code unit = 'a'
 Last code unit = 'd'
 Subject length lower bound = 4
 
+# None of the following three should have the starting code unit, required code unit, and minimum length set:
 /abcd/I,no_start_optimize
 Capture group count = 0
 Options: no_start_optimize
+Optimizations: auto_possess,dotstar_anchor
+
+/abcd/I,start_optimize_off
+Capture group count = 0
+Optimizations: auto_possess,dotstar_anchor
+
+/abcd/I,optimization_none
+Capture group count = 0
+Optimizations: <none>
 
 /(|ab)*?d/I
 Capture group count = 1
@@ -13616,6 +13681,7 @@ Subject length lower bound = 1
 /(|ab)*?d/I,no_start_optimize
 Capture group count = 1
 Options: no_start_optimize
+Optimizations: auto_possess,dotstar_anchor
    abd
  0: abd
  1: ab
@@ -13887,7 +13953,79 @@ Subject length lower bound = 3
 Capture group count = 0
 Compile options: no_dotstar_anchor
 Overall options: anchored no_dotstar_anchor
+Optimizations: auto_possess,start_optimize
 First code unit = 'a'
+Subject length lower bound = 3
+
+/^abc/info,dotstar_anchor_off
+Capture group count = 0
+Compile options: <none>
+Overall options: anchored
+Optimizations: auto_possess,start_optimize
+First code unit = 'a'
+Subject length lower bound = 3
+
+# For comparison with the following tests, which disable automatic dotstar anchoring
+/.*abc/BI
+------------------------------------------------------------------
+        Bra
+        Any*
+        abc
+        Ket
+        End
+------------------------------------------------------------------
+Capture group count = 0
+First code unit at start or follows newline
+Last code unit = 'c'
+Subject length lower bound = 3
+
+/.*abc/BI,dotstar_anchor_off
+------------------------------------------------------------------
+        Bra
+        Any*
+        abc
+        Ket
+        End
+------------------------------------------------------------------
+Capture group count = 0
+Optimizations: auto_possess,start_optimize
+Last code unit = 'c'
+Subject length lower bound = 3
+
+/.*abc/BI,start_optimize_off
+------------------------------------------------------------------
+        Bra
+        Any*
+        abc
+        Ket
+        End
+------------------------------------------------------------------
+Capture group count = 0
+Optimizations: auto_possess,dotstar_anchor
+
+/.*abc/BI,optimization_none
+------------------------------------------------------------------
+        Bra
+        Any*
+        abc
+        Ket
+        End
+------------------------------------------------------------------
+Capture group count = 0
+Optimizations: <none>
+
+/.*abc/BI,no_dotstar_anchor
+------------------------------------------------------------------
+        Bra
+        Any*
+        abc
+        Ket
+        End
+------------------------------------------------------------------
+Capture group count = 0
+Options: no_dotstar_anchor
+Optimizations: auto_possess,start_optimize
+Last code unit = 'c'
 Subject length lower bound = 3
 
 /.*\d/info,auto_callout
@@ -13908,6 +14046,7 @@ No match
 /.*\d/info,no_dotstar_anchor,auto_callout
 Capture group count = 0
 Options: auto_callout no_dotstar_anchor
+Optimizations: auto_possess,start_optimize
 Subject length lower bound = 1
 \= Expect no match
     aaa
@@ -13935,12 +14074,14 @@ Subject length lower bound = 1
 /.*\d/dotall,no_dotstar_anchor,info
 Capture group count = 0
 Options: dotall no_dotstar_anchor
+Optimizations: auto_possess,start_optimize
 Subject length lower bound = 1
 
 /(*NO_DOTSTAR_ANCHOR)(?s).*\d/info
 Capture group count = 0
 Compile options: <none>
 Overall options: no_dotstar_anchor
+Optimizations: auto_possess,start_optimize
 Subject length lower bound = 1
 
 '^(?:(a)|b)(?(1)A|B)'
@@ -16430,6 +16571,36 @@ No match
     syndicate
 No match
 
+# Confirm that the pcre2_set_optimize API does not have any undesired effect on literal patterns
+/(cat)|dog/literal,auto_possess_off
+    (cat)|dog
+ 0: (cat)|dog
+\= Expect no match
+    the cat sat
+No match
+
+/(cat)|dog/literal,dotstar_anchor_off
+    (cat)|dog
+ 0: (cat)|dog
+\= Expect no match
+    the cat sat
+No match
+
+/(cat)|dog/literal,optimization_none
+    (cat)|dog
+ 0: (cat)|dog
+\= Expect no match
+    the cat sat
+No match
+
+# These should result in errors, since it is not permitted to use the
+# PCRE2_NO_AUTO_POSSESS and PCRE2_NO_DOTSTAR_ANCHOR options on a literal pattern
+/(cat)|dog/literal,no_auto_possess
+Failed: error 192 at offset 0: invalid option bits with PCRE2_LITERAL
+
+/(cat)|dog/literal,no_dotstar_anchor
+Failed: error 192 at offset 0: invalid option bits with PCRE2_LITERAL
+
 /a whole line/match_line,multiline
     Rhubarb \na whole line\n custard
  0: a whole line
@@ -18049,12 +18220,14 @@ Subject length lower bound = 1
 /a?(?=b(*COMMIT)c|)d/I,no_start_optimize
 Capture group count = 0
 Options: no_start_optimize
+Optimizations: auto_possess,dotstar_anchor
     bd
 No match
 
 /(?=b(*COMMIT)c|)d/I,no_start_optimize
 Capture group count = 0
 Options: no_start_optimize
+Optimizations: auto_possess,dotstar_anchor
     bd
 No match
 
@@ -19059,6 +19232,57 @@ No match
  1: a
     ac
 No match
+
+# Tests for pcre2_set_optimize()
+
+/abc/I,optimization_none
+Capture group count = 0
+Optimizations: <none>
+
+/abc/I,optimization_none,auto_possess
+Capture group count = 0
+Optimizations: auto_possess
+
+/abc/I,optimization_none,dotstar_anchor,auto_possess
+Capture group count = 0
+Optimizations: auto_possess,dotstar_anchor
+
+/abc/I,optimization_none,start_optimize
+Capture group count = 0
+Optimizations: start_optimize
+First code unit = 'a'
+Last code unit = 'c'
+Subject length lower bound = 3
+
+/abc/I,dotstar_anchor_off,optimization_full
+Capture group count = 0
+First code unit = 'a'
+Last code unit = 'c'
+Subject length lower bound = 3
+
+# If pcre2_set_optimize() is used to turn on some optimization, but at the same time,
+# the compile options word turns it off... the compile options word "wins":
+
+/abc/I,no_auto_possess,auto_possess
+Capture group count = 0
+Options: no_auto_possess
+Optimizations: dotstar_anchor,start_optimize
+First code unit = 'a'
+Last code unit = 'c'
+Subject length lower bound = 3
+
+/abc/I,no_dotstar_anchor,dotstar_anchor
+Capture group count = 0
+Options: no_dotstar_anchor
+Optimizations: auto_possess,start_optimize
+First code unit = 'a'
+Last code unit = 'c'
+Subject length lower bound = 3
+
+/abc/I,no_start_optimize,start_optimize
+Capture group count = 0
+Options: no_start_optimize
+Optimizations: auto_possess,dotstar_anchor
 
 # --------------
 

--- a/testdata/testoutput2
+++ b/testdata/testoutput2
@@ -16572,21 +16572,34 @@ No match
 No match
 
 # Confirm that the pcre2_set_optimize API does not have any undesired effect on literal patterns
-/(cat)|dog/literal,auto_possess_off
+/(cat)|dog/I,literal,auto_possess_off
+Capture group count = 0
+Options: literal
+First code unit = '('
+Last code unit = 'g'
+Subject length lower bound = 9
     (cat)|dog
  0: (cat)|dog
 \= Expect no match
     the cat sat
 No match
 
-/(cat)|dog/literal,dotstar_anchor_off
+/(cat)|dog/I,literal,dotstar_anchor_off
+Capture group count = 0
+Options: literal
+First code unit = '('
+Last code unit = 'g'
+Subject length lower bound = 9
     (cat)|dog
  0: (cat)|dog
 \= Expect no match
     the cat sat
 No match
 
-/(cat)|dog/literal,optimization_none
+/(cat)|dog/I,literal,optimization_none
+Capture group count = 0
+Options: literal
+Optimizations: auto_possess,dotstar_anchor
     (cat)|dog
  0: (cat)|dog
 \= Expect no match

--- a/testdata/testoutput5
+++ b/testdata/testoutput5
@@ -474,6 +474,7 @@ Subject length lower bound = 0
 Capture group count = 0
 Compile options: no_start_optimize utf
 Overall options: anchored no_start_optimize utf
+Optimizations: auto_possess,dotstar_anchor
 
 /()()()()()()()()()()
  ()()()()()()()()()()

--- a/testdata/testoutput6
+++ b/testdata/testoutput6
@@ -6860,6 +6860,7 @@ No match
 /(abc|def|xyz)/I,no_start_optimize
 Capture group count = 1
 Options: no_start_optimize
+Optimizations: auto_possess,dotstar_anchor
     terhjk;abcdaadsfe
  0: abc
     the quick xyz brown fox


### PR DESCRIPTION
Ignore "disabling"of the two optimizations that PCRE2_LITERAL doesn't expect to handle and that would trigger an error from pcre2_compile()

Document the expected behaviour